### PR TITLE
fix(tunnel): Redact sensitive connection data

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ requests. If the WebSocket disconnects, in-flight work is cancelled and never re
 tunnels reacquire their slug on reconnect, while requests already dispatched to localhost are
 reported by the service as having an unknown outcome.
 
+Machine-readable tunnel receipts redact authorization, cookies, API keys, tokens, and secret
+header values. Debug logs omit the access-token query parameter from WebSocket endpoints.
+
 ## Work with captured requests
 
 Select an organization once for account-backed commands:

--- a/src/main.rs
+++ b/src/main.rs
@@ -870,6 +870,35 @@ fn tunnel_event_base(event: &str, status: &str) -> serde_json::Value {
     command_event_receipt("tunnel", "start_local_tunnel", event, status)
 }
 
+fn redact_tunnel_headers(
+    headers: &std::collections::HashMap<String, String>,
+) -> std::collections::HashMap<String, String> {
+    headers
+        .iter()
+        .map(|(name, value)| {
+            let value = if sensitive_header_name(name) {
+                "[REDACTED]".to_string()
+            } else {
+                value.clone()
+            };
+
+            (name.clone(), value)
+        })
+        .collect()
+}
+
+fn sensitive_header_name(name: &str) -> bool {
+    let normalized = name.to_ascii_lowercase().replace('_', "-");
+
+    matches!(
+        normalized.as_str(),
+        "authorization" | "proxy-authorization" | "cookie" | "set-cookie"
+    ) || normalized.contains("token")
+        || normalized.contains("secret")
+        || normalized.contains("api-key")
+        || normalized.ends_with("-key")
+}
+
 fn reconnect_failure_reason(event: &TunnelEvent) -> Option<&str> {
     match event {
         TunnelEvent::ReconnectFailed { reason } => Some(reason),
@@ -1197,7 +1226,7 @@ fn tunnel_event_receipt(
             receipt["query_string"] = serde_json::json!(query_string);
             receipt["local_target_url"] =
                 serde_json::json!(local_tunnel_request_target(host, port, path, query_string));
-            receipt["headers"] = serde_json::json!(headers);
+            receipt["headers"] = serde_json::json!(redact_tunnel_headers(headers));
             receipt["body_size"] = serde_json::json!(body.as_ref().map(String::len).unwrap_or(0));
             receipt
         }
@@ -1215,7 +1244,8 @@ fn tunnel_event_receipt(
             receipt["request_resource_uri"] = serde_json::json!(&request_resource_uri);
             receipt["status_code"] = serde_json::json!(status);
             receipt["duration_ms"] = serde_json::json!(duration_ms);
-            receipt["response_headers"] = serde_json::json!(response_headers);
+            receipt["response_headers"] =
+                serde_json::json!(redact_tunnel_headers(response_headers));
             receipt["response_body_size"] =
                 serde_json::json!(response_body.as_ref().map(String::len).unwrap_or(0));
             receipt
@@ -5336,6 +5366,67 @@ mod tests {
         );
         assert_eq!(receipt["body_size"], 11);
         assert_eq!(receipt["headers"]["content-type"], "application/json");
+    }
+
+    #[test]
+    fn tunnel_request_event_redacts_sensitive_headers() {
+        let headers = std::collections::HashMap::from([
+            (
+                "authorization".to_string(),
+                "Bearer request-secret".to_string(),
+            ),
+            ("cookie".to_string(), "session=request-secret".to_string()),
+            ("x-api-key".to_string(), "request-api-key".to_string()),
+            ("content-type".to_string(), "application/json".to_string()),
+        ]);
+        let event = TunnelEvent::RequestReceived {
+            request_id: "req_secure".to_string(),
+            method: "POST".to_string(),
+            path: "/webhook".to_string(),
+            headers,
+            body: None,
+            query_string: String::new(),
+        };
+
+        let receipt = tunnel_event_receipt(&event, "127.0.0.1", 8080, None, None);
+
+        assert_eq!(receipt["headers"]["authorization"], "[REDACTED]");
+        assert_eq!(receipt["headers"]["cookie"], "[REDACTED]");
+        assert_eq!(receipt["headers"]["x-api-key"], "[REDACTED]");
+        assert_eq!(receipt["headers"]["content-type"], "application/json");
+        let output = receipt.to_string();
+        assert!(!output.contains("request-secret"));
+        assert!(!output.contains("request-api-key"));
+    }
+
+    #[test]
+    fn tunnel_response_event_redacts_sensitive_headers() {
+        let event = TunnelEvent::RequestForwarded {
+            request_id: "req_secure".to_string(),
+            status: 200,
+            duration_ms: 10,
+            response_headers: std::collections::HashMap::from([
+                (
+                    "set-cookie".to_string(),
+                    "session=response-secret".to_string(),
+                ),
+                ("x-auth-token".to_string(), "response-token".to_string()),
+                ("content-type".to_string(), "application/json".to_string()),
+            ]),
+            response_body: None,
+        };
+
+        let receipt = tunnel_event_receipt(&event, "127.0.0.1", 8080, None, None);
+
+        assert_eq!(receipt["response_headers"]["set-cookie"], "[REDACTED]");
+        assert_eq!(receipt["response_headers"]["x-auth-token"], "[REDACTED]");
+        assert_eq!(
+            receipt["response_headers"]["content-type"],
+            "application/json"
+        );
+        let output = receipt.to_string();
+        assert!(!output.contains("response-secret"));
+        assert!(!output.contains("response-token"));
     }
 
     #[test]

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -23,6 +23,7 @@ const LEGACY_MAX_RESPONSE_BODY_BYTES: usize = 7_000_000;
 const LEGACY_MAX_RESPONSE_HEADER_BYTES: usize = 1_048_576;
 const MAX_RAW_BODY_BYTES: usize = 1_048_576;
 const UI_BODY_PREVIEW_BYTES: usize = 65_536;
+const REDACTED_SECRET: &str = "[REDACTED]";
 
 #[derive(Clone, Copy, Debug)]
 struct TunnelLimits {
@@ -259,17 +260,27 @@ impl Default for ReconnectConfig {
     }
 }
 
-/// Build a WebSocket URL from a base HTTP(S) URL
-#[cfg(test)]
-pub fn build_ws_url(base_url: &str, token: &str, path: &str) -> String {
+fn websocket_endpoint(base_url: &str, path: &str) -> String {
     format!(
-        "{}/{}?token={}",
+        "{}/{}",
         base_url
             .replace("https://", "wss://")
             .replace("http://", "ws://"),
-        path.trim_start_matches('/'),
-        token
+        path.trim_start_matches('/')
     )
+}
+
+/// Build a WebSocket URL from a base HTTP(S) URL.
+pub fn build_ws_url(base_url: &str, token: &str, path: &str) -> String {
+    format!("{}?token={token}", websocket_endpoint(base_url, path))
+}
+
+fn redact_access_token(message: &str, access_token: &str) -> String {
+    if access_token.is_empty() {
+        message.to_string()
+    } else {
+        message.replace(access_token, REDACTED_SECRET)
+    }
 }
 
 /// Build a target URL for forwarding, appending path and optional query params
@@ -376,15 +387,12 @@ impl TunnelClient {
 
         // Build WebSocket URL with auth token
         let access_token = self.access_token_rx.borrow().clone();
-        let ws_url = format!(
-            "{}/socket/websocket?token={}",
-            self.base_url
-                .replace("https://", "wss://")
-                .replace("http://", "ws://"),
-            access_token
-        );
+        let ws_url = build_ws_url(&self.base_url, &access_token, "socket/websocket");
 
-        debug!("WebSocket URL: {}", ws_url);
+        debug!(
+            endpoint = %websocket_endpoint(&self.base_url, "socket/websocket"),
+            "Connecting to WebSocket"
+        );
 
         // Connect to WebSocket
         let (ws_stream, _) = match connect_async(&ws_url).await {
@@ -425,7 +433,8 @@ impl TunnelClient {
                     return Err(anyhow!(msg));
                 }
                 _ => {
-                    let msg = format!("Failed to connect to WebSocket: {}", e);
+                    let detail = redact_access_token(&e.to_string(), &access_token);
+                    let msg = format!("Failed to connect to WebSocket: {detail}");
                     let _ = self
                         .event_tx
                         .send(TunnelEvent::ConnectionError(msg.clone()))
@@ -929,15 +938,12 @@ impl TunnelForwarder {
 
         // Build WebSocket URL - connect to /tunnel/websocket endpoint (Phoenix default)
         let access_token = self.access_token_rx.borrow().clone();
-        let ws_url = format!(
-            "{}/tunnel/websocket?token={}",
-            self.base_url
-                .replace("https://", "wss://")
-                .replace("http://", "ws://"),
-            access_token
-        );
+        let ws_url = build_ws_url(&self.base_url, &access_token, "tunnel/websocket");
 
-        debug!("Tunnel WebSocket URL: {}", ws_url);
+        debug!(
+            endpoint = %websocket_endpoint(&self.base_url, "tunnel/websocket"),
+            "Connecting tunnel WebSocket"
+        );
 
         // Connect to WebSocket
         let (ws_stream, _) = match connect_async_with_config(
@@ -949,7 +955,8 @@ impl TunnelForwarder {
         {
             Ok(stream) => stream,
             Err(e) => {
-                let msg = format!("Failed to connect to tunnel: {}", e);
+                let detail = redact_access_token(&e.to_string(), &access_token);
+                let msg = format!("Failed to connect to tunnel: {detail}");
                 let _ = self
                     .event_tx
                     .send(TunnelEvent::ConnectionError(msg.clone()))
@@ -1866,6 +1873,24 @@ mod tests {
     fn test_build_ws_url_http_to_ws() {
         let url = build_ws_url("http://localhost:4000", "tok", "tunnel/websocket");
         assert_eq!(url, "ws://localhost:4000/tunnel/websocket?token=tok");
+    }
+
+    #[test]
+    fn test_websocket_endpoint_omits_access_token() {
+        let endpoint = websocket_endpoint("https://api.example.com", "tunnel/websocket");
+
+        assert_eq!(endpoint, "wss://api.example.com/tunnel/websocket");
+        assert!(!endpoint.contains("token="));
+    }
+
+    #[test]
+    fn test_redact_access_token_from_connection_errors() {
+        let token = "public-cli-secret-token";
+        let error = format!("request failed for wss://api.example.com/tunnel?token={token}");
+        let redacted = redact_access_token(&error, token);
+
+        assert!(!redacted.contains(token));
+        assert!(redacted.contains(REDACTED_SECRET));
     }
 
     // build_forward_target tests


### PR DESCRIPTION
## Summary

- keep access tokens out of WebSocket debug endpoints and sanitize token-bearing connection errors
- redact credential-bearing request and response headers in machine-readable tunnel receipts
- document the output-safety contract and add regression coverage

## Validation

- cargo fmt -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test (241 passed)
- cargo build
- end-to-end tunnel security smoke (3/3 scenarios)