### PR TITLE
chore(release): Prepare v1.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,7 +1166,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hooklistener-cli"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hooklistener-cli"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2024"
 autobins = false
 description = "A fast, terminal-based CLI for browsing webhooks, forwarding events, and exposing local servers"

--- a/npm/packages/hooklistener/package.json
+++ b/npm/packages/hooklistener/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hooklistener",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A fast, terminal-based CLI for browsing webhooks, forwarding events, and exposing local servers",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

- bump the Cargo crate and lockfile package version to 1.4.1
- bump the npm installer wrapper to the same version
- prepare the patch release for the tunnel fixes merged in [#20](https://github.com/hooklistener/hooklistener-cli/pull/20), [#21](https://github.com/hooklistener/hooklistener-cli/pull/21), and [#22](https://github.com/hooklistener/hooklistener-cli/pull/22)

## Release highlights

- preserve response status, binary bodies, encodings, ordered duplicate headers, redirects, and advertised limits
- forward tunnel requests concurrently while cancelling connection-owned work safely during reconnects
- keep access tokens out of WebSocket diagnostics and redact credential-bearing headers from JSON receipts

## Validation

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo test --all-targets --all-features --locked (241 passed)
- cargo build --release --locked
- cargo publish --dry-run --allow-dirty --locked
- npm pack --dry-run (hooklistener@1.4.1)
- target/release/hooklistener --version reports 1.4.1

After merge, pushing tag v1.4.1 will trigger the existing GitHub release, crates.io, npm, and Homebrew publishing workflow.