### PR TITLE
feat(tunnel): enforce local target policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ hooklistener listen stripe-sandbox \
   --target http://localhost:3000/webhooks/stripe
 ```
 
+Listener targets are loopback-only by default. Hooklistener resolves and pins the target address,
+does not follow redirects, ignores proxy environment variables, and rejects target URLs containing
+credentials, query strings, or fragments. Use `--allow-non-loopback` only for an explicitly trusted
+remote target. HTTPS certificate verification can be disabled only with the visible
+`--insecure-tls` opt-in.
+
 ### Try it without logging in
 
 Create a temporary anonymous endpoint:

--- a/src/api.rs
+++ b/src/api.rs
@@ -7,7 +7,9 @@ use reqwest::{
 use serde::{Deserialize, Deserializer, Serialize, de::DeserializeOwned};
 use serde_json::Value;
 use std::collections::HashMap;
-use std::time::Instant;
+use std::time::{Duration, Instant};
+
+const RELAY_TICKET_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 fn deserialize_map_or_default<'de, D>(
     deserializer: D,
@@ -23,6 +25,19 @@ where
 pub struct Organization {
     pub id: String,
     pub name: String,
+}
+
+#[derive(Clone, Deserialize)]
+pub struct RelayTicket {
+    pub ticket: String,
+    pub scope: String,
+    pub plan_fingerprint: String,
+    pub expires_at: String,
+}
+
+#[derive(Deserialize)]
+struct RelayTicketEnvelope {
+    data: RelayTicket,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -529,6 +544,47 @@ pub async fn revoke_refresh_token(refresh_token: &str) -> Result<()> {
     let client = Client::new();
     let _ = client.post(&url).json(&body).send().await;
     Ok(())
+}
+
+/// Exchange a long-lived HTTP credential for a short-lived relay handshake ticket.
+pub async fn issue_relay_ticket(
+    access_token: &str,
+    base_url: &str,
+    plan: &Value,
+) -> Result<RelayTicket> {
+    let http_base = base_url
+        .replacen("wss://", "https://", 1)
+        .replacen("ws://", "http://", 1);
+    let url = format!(
+        "{}/api/v1/tunnel/relay-tickets",
+        http_base.trim_end_matches('/')
+    );
+
+    let response = Client::new()
+        .post(url)
+        .bearer_auth(access_token)
+        .json(&serde_json::json!({"plan": plan}))
+        .timeout(RELAY_TICKET_REQUEST_TIMEOUT)
+        .send()
+        .await
+        .context("Failed to request relay handshake ticket")?;
+    let status = response.status();
+    let text = response.text().await.unwrap_or_default();
+
+    if !status.is_success() {
+        let permanent_client_error =
+            status.is_client_error() && !matches!(status.as_u16(), 408 | 429);
+        let failure = if permanent_client_error {
+            "Relay handshake rejected"
+        } else {
+            "Relay handshake ticket request failed"
+        };
+        return Err(anyhow!("{} (HTTP {}): {}", failure, status, text));
+    }
+
+    serde_json::from_str::<RelayTicketEnvelope>(&text)
+        .map(|envelope| envelope.data)
+        .context("Failed to parse relay handshake ticket")
 }
 
 impl ApiClient {
@@ -1115,6 +1171,64 @@ mod tests {
     use super::*;
     use flate2::{Compression, write::GzEncoder};
     use std::io::Write;
+
+    #[tokio::test]
+    async fn relay_ticket_exchange_uses_authorization_header_and_parses_safe_receipt() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/api/v1/tunnel/relay-tickets")
+            .match_header("authorization", "Bearer access-secret")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "plan": {"mode": "capture_forward"}
+            })))
+            .with_status(201)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"ticket":"hktr_once","scope":"relay:listen","plan_fingerprint":"fingerprint","expires_at":"2026-07-14T20:01:00Z"}}"#,
+            )
+            .create_async()
+            .await;
+
+        let ticket = issue_relay_ticket(
+            "access-secret",
+            &server.url(),
+            &serde_json::json!({"mode": "capture_forward"}),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(ticket.ticket, "hktr_once");
+        assert_eq!(ticket.scope, "relay:listen");
+        assert_eq!(ticket.plan_fingerprint, "fingerprint");
+        assert_eq!(ticket.expires_at, "2026-07-14T20:01:00Z");
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn relay_ticket_exchange_classifies_permanent_http_rejections() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/api/v1/tunnel/relay-tickets")
+            .with_status(401)
+            .with_body(r#"{"error":{"code":"unauthorized"}}"#)
+            .create_async()
+            .await;
+
+        let error = match issue_relay_ticket(
+            "expired-secret",
+            &server.url(),
+            &serde_json::json!({"mode": "capture_forward"}),
+        )
+        .await
+        {
+            Ok(_) => panic!("expected relay-ticket rejection"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("Relay handshake rejected"));
+        assert!(error.to_string().contains("HTTP 401 Unauthorized"));
+        mock.assert_async().await;
+    }
 
     #[tokio::test]
     async fn test_forward_request_success() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,12 @@ impl Config {
 
     pub fn load_from(path: &Path) -> Result<Self> {
         if path.exists() {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+            }
+
             let content = fs::read_to_string(path)?;
             let config: Config = serde_json::from_str(&content)?;
             Ok(config)
@@ -46,7 +52,29 @@ impl Config {
         }
 
         let content = serde_json::to_string_pretty(self)?;
-        fs::write(path, content)?;
+
+        #[cfg(unix)]
+        {
+            use std::io::Write;
+            use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+            let mut file = fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .mode(0o600)
+                .open(path)?;
+
+            // OpenOptions::mode applies only when creating a file. Tighten an
+            // existing file before writing the new credentials as well.
+            fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+            file.write_all(content.as_bytes())?;
+        }
+
+        #[cfg(not(unix))]
+        {
+            fs::write(path, content)?;
+        }
 
         Ok(())
     }
@@ -224,6 +252,15 @@ mod tests {
         assert_eq!(loaded.access_token.as_deref(), Some("roundtrip_token"));
         assert_eq!(loaded.selected_organization_id.as_deref(), Some("org-rt"));
         assert!(loaded.is_token_valid());
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
     }
 
     #[test]

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -242,7 +242,13 @@ impl Logger {
         // Remove sensitive data
         if let Some(obj) = config.as_object_mut() {
             obj.remove("access_token");
+            obj.remove("refresh_token");
             if let Some(token_expires) = obj.get_mut("token_expires_at")
+                && token_expires.is_string()
+            {
+                *token_expires = serde_json::Value::String("[REDACTED]".to_string());
+            }
+            if let Some(token_expires) = obj.get_mut("refresh_token_expires_at")
                 && token_expires.is_string()
             {
                 *token_expires = serde_json::Value::String("[REDACTED]".to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod logo;
 mod models;
 mod output;
 mod syntax;
+mod target_policy;
 mod theme;
 mod tunnel;
 mod ui;
@@ -99,6 +100,14 @@ enum Commands {
         /// WebSocket server URL (defaults to production)
         #[arg(long)]
         ws_url: Option<String>,
+
+        /// Allow forwarding to a target that resolves outside loopback
+        #[arg(long)]
+        allow_non_loopback: bool,
+
+        /// Disable target TLS certificate verification (visible and plan-bound)
+        #[arg(long)]
+        insecure_tls: bool,
     },
     /// Generate a diagnostic bundle for support
     Diagnostics {
@@ -179,6 +188,10 @@ enum Commands {
         /// Static tunnel slug (paid plans only, creates persistent subdomain)
         #[arg(short, long)]
         slug: Option<String>,
+
+        /// Allow forwarding to a host that resolves outside loopback
+        #[arg(long)]
+        allow_non_loopback: bool,
 
         /// Do not automatically replay requests buffered while the tunnel was offline
         #[arg(long)]
@@ -1634,7 +1647,12 @@ async fn run_listen_json(
     target_url: String,
     ws_url: Option<String>,
     organization_id: Option<String>,
+    allow_non_loopback: bool,
+    insecure_tls: bool,
 ) -> Result<()> {
+    let target =
+        target_policy::TargetPolicy::resolve(&target_url, allow_non_loopback, insecure_tls).await?;
+    let target_url = target.display_url();
     let access_token = access_token_rx.borrow().clone();
     let endpoint = resolve_listen_endpoint(&access_token, organization_id, &endpoint_slug).await;
 
@@ -1649,7 +1667,7 @@ async fn run_listen_json(
     let tunnel_client = tunnel::TunnelClient::new(
         access_token_rx,
         endpoint_slug.clone(),
-        target_url.clone(),
+        target,
         ws_url,
         event_tx,
     );
@@ -1717,6 +1735,7 @@ async fn run_tunnel_json(
     port: u16,
     organization_id: Option<String>,
     slug: Option<String>,
+    target: target_policy::TargetPolicy,
     replay_buffered: bool,
 ) -> Result<()> {
     print_json_line(&tunnel_started_receipt(
@@ -1733,6 +1752,7 @@ async fn run_tunnel_json(
         port,
         organization_id.clone(),
         slug.clone(),
+        target,
         event_tx,
         replay_buffered,
     ));
@@ -1816,6 +1836,8 @@ async fn run(cli: Cli) -> Result<()> {
             endpoint,
             target,
             ws_url,
+            allow_non_loopback,
+            insecure_tls,
         } => {
             // Initialize logging for tunnel
             let log_config = LogConfig {
@@ -1840,9 +1862,16 @@ async fn run(cli: Cli) -> Result<()> {
                     target,
                     ws_url,
                     selected_organization_id,
+                    allow_non_loopback,
+                    insecure_tls,
                 )
                 .await?;
             } else {
+                let target_policy =
+                    target_policy::TargetPolicy::resolve(&target, allow_non_loopback, insecure_tls)
+                        .await?;
+                let target = target_policy.display_url();
+
                 // Setup TUI for listen command
                 let mut terminal = setup_terminal()?;
                 let mut app = App::new()?;
@@ -1860,7 +1889,7 @@ async fn run(cli: Cli) -> Result<()> {
                 let tunnel_client = tunnel::TunnelClient::new(
                     access_token_rx,
                     endpoint.clone(),
-                    target.clone(),
+                    target_policy,
                     ws_url,
                     event_tx,
                 );
@@ -1958,16 +1987,11 @@ async fn run(cli: Cli) -> Result<()> {
                     print_field("CONFIG FILE", config_path.display());
                     println!();
                     match &config.access_token {
-                        Some(token) => {
-                            let truncated = if token.len() > 8 {
-                                format!("{}...", &token[..8])
-                            } else {
-                                token.clone()
-                            };
+                        Some(_) => {
                             if config.is_token_valid() {
-                                print_field("TOKEN", format!("{truncated} {}", "(valid)".green()));
+                                print_field("TOKEN", "(present, valid)".green());
                             } else {
-                                print_field("TOKEN", format!("{truncated} {}", "(expired)".red()));
+                                print_field("TOKEN", "(present, expired)".red());
                             }
                         }
                         None => print_field("TOKEN", "(none)".dim()),
@@ -2907,6 +2931,7 @@ async fn run(cli: Cli) -> Result<()> {
             host,
             org,
             slug,
+            allow_non_loopback,
             no_replay_buffered,
         } => {
             // Initialize logging for tunnel
@@ -2924,6 +2949,12 @@ async fn run(cli: Cli) -> Result<()> {
             let selected_org = resolve_tunnel_org(org, &config);
             let access_token = ensure_valid_token(&mut config).await?;
             let access_token_rx = refreshed_access_token_rx(access_token, config);
+            let target = target_policy::TargetPolicy::resolve(
+                &local_tunnel_target_url(&host, port),
+                allow_non_loopback,
+                false,
+            )
+            .await?;
 
             let replay_buffered = !no_replay_buffered;
 
@@ -2934,6 +2965,7 @@ async fn run(cli: Cli) -> Result<()> {
                     port,
                     selected_org,
                     slug,
+                    target,
                     replay_buffered,
                 )
                 .await?;
@@ -2961,6 +2993,7 @@ async fn run(cli: Cli) -> Result<()> {
                     port,
                     selected_org,
                     slug,
+                    target,
                     event_tx.clone(),
                     replay_buffered,
                 );
@@ -4164,12 +4197,14 @@ fn print_uptime_checks(response: &api::UptimeChecksResponse) {
     print_pagination(&response.pagination);
 }
 
+#[allow(clippy::too_many_arguments)]
 fn spawn_tunnel_forwarder_manager(
     access_token_rx: watch::Receiver<String>,
     host: String,
     port: u16,
     org: Option<String>,
     slug: Option<String>,
+    target: target_policy::TargetPolicy,
     event_tx: mpsc::Sender<TunnelEvent>,
     replay_buffered: bool,
 ) -> mpsc::UnboundedSender<()> {
@@ -4182,6 +4217,7 @@ fn spawn_tunnel_forwarder_manager(
             port,
             org.clone(),
             slug.clone(),
+            target.clone(),
             event_tx.clone(),
             replay_buffered,
         ));
@@ -4199,6 +4235,7 @@ fn spawn_tunnel_forwarder_manager(
                 port,
                 org.clone(),
                 slug.clone(),
+                target.clone(),
                 event_tx.clone(),
                 replay_buffered,
             ));
@@ -4211,12 +4248,14 @@ fn spawn_tunnel_forwarder_manager(
     reconnect_tx
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_tunnel_forwarder_connection(
     access_token_rx: watch::Receiver<String>,
     host: String,
     port: u16,
     org: Option<String>,
     slug: Option<String>,
+    target: target_policy::TargetPolicy,
     event_tx: mpsc::Sender<TunnelEvent>,
     replay_buffered: bool,
 ) {
@@ -4224,6 +4263,7 @@ async fn run_tunnel_forwarder_connection(
         access_token_rx,
         host,
         port,
+        target,
         org,
         slug,
         event_tx,

--- a/src/target_policy.rs
+++ b/src/target_policy.rs
@@ -1,0 +1,372 @@
+use reqwest::{Client, Url, redirect::Policy};
+use serde::Serialize;
+use std::collections::BTreeSet;
+use std::fmt;
+use std::net::{IpAddr, SocketAddr};
+use std::time::Duration;
+
+#[derive(Clone, Debug)]
+pub struct TargetPolicy {
+    url: Url,
+    host: String,
+    port: u16,
+    pinned_addresses: Vec<SocketAddr>,
+    allow_non_loopback: bool,
+    insecure_tls: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct TargetPlan {
+    pub scheme: String,
+    pub host: String,
+    pub port: u16,
+    pub path: String,
+    pub pinned_addresses: Vec<String>,
+    pub allow_non_loopback: bool,
+    pub insecure_tls: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TargetPolicyError {
+    code: &'static str,
+    message: String,
+}
+
+impl TargetPolicyError {
+    fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+
+    pub fn code(&self) -> &'static str {
+        self.code
+    }
+}
+
+impl fmt::Display for TargetPolicyError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}: {}", self.code(), self.message)
+    }
+}
+
+impl std::error::Error for TargetPolicyError {}
+
+impl TargetPolicy {
+    pub async fn resolve(
+        raw: &str,
+        allow_non_loopback: bool,
+        insecure_tls: bool,
+    ) -> Result<Self, TargetPolicyError> {
+        let url = Url::parse(raw).map_err(|error| {
+            TargetPolicyError::new("target_url_invalid", format!("Invalid target URL: {error}"))
+        })?;
+
+        if !matches!(url.scheme(), "http" | "https") {
+            return Err(TargetPolicyError::new(
+                "target_scheme_invalid",
+                "Target scheme must be http or https",
+            ));
+        }
+        if !url.username().is_empty() || url.password().is_some() {
+            return Err(TargetPolicyError::new(
+                "target_credentials_forbidden",
+                "Target URLs must not contain credentials",
+            ));
+        }
+        if url.query().is_some() {
+            return Err(TargetPolicyError::new(
+                "target_query_forbidden",
+                "Target URLs must not contain a query string",
+            ));
+        }
+        if url.fragment().is_some() {
+            return Err(TargetPolicyError::new(
+                "target_fragment_forbidden",
+                "Target URLs must not contain a fragment",
+            ));
+        }
+        if insecure_tls && url.scheme() != "https" {
+            return Err(TargetPolicyError::new(
+                "target_insecure_tls_invalid",
+                "--insecure-tls applies only to HTTPS targets",
+            ));
+        }
+
+        let host = url
+            .host_str()
+            .ok_or_else(|| {
+                TargetPolicyError::new("target_authority_invalid", "Target host is required")
+            })?
+            .to_ascii_lowercase();
+        let port = url.port_or_known_default().ok_or_else(|| {
+            TargetPolicyError::new("target_port_invalid", "Target port is required")
+        })?;
+
+        let resolved = tokio::net::lookup_host((host.as_str(), port))
+            .await
+            .map_err(|error| {
+                TargetPolicyError::new(
+                    "target_dns_failed",
+                    format!("Target host could not be resolved: {error}"),
+                )
+            })?;
+
+        let pinned_addresses: Vec<SocketAddr> = resolved
+            .map(|address| SocketAddr::new(address.ip(), port))
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+
+        if pinned_addresses.is_empty() {
+            return Err(TargetPolicyError::new(
+                "target_dns_empty",
+                "Target host resolved to no addresses",
+            ));
+        }
+
+        if !allow_non_loopback
+            && pinned_addresses
+                .iter()
+                .any(|address| !address.ip().is_loopback())
+        {
+            return Err(TargetPolicyError::new(
+                "target_non_loopback_requires_scope",
+                "Non-loopback targets require --allow-non-loopback",
+            ));
+        }
+
+        if pinned_addresses
+            .iter()
+            .any(|address| forbidden_address(address.ip()))
+        {
+            return Err(TargetPolicyError::new(
+                "target_address_forbidden",
+                "Target resolved to an unspecified, multicast, or broadcast address",
+            ));
+        }
+
+        Ok(Self {
+            url,
+            host,
+            port,
+            pinned_addresses,
+            allow_non_loopback,
+            insecure_tls,
+        })
+    }
+
+    pub fn plan(&self) -> TargetPlan {
+        TargetPlan {
+            scheme: self.url.scheme().to_string(),
+            host: self.host.clone(),
+            port: self.port,
+            path: normalized_path(self.url.path()),
+            pinned_addresses: self
+                .pinned_addresses
+                .iter()
+                .map(|address| address.ip().to_string())
+                .collect(),
+            allow_non_loopback: self.allow_non_loopback,
+            insecure_tls: self.insecure_tls,
+        }
+    }
+
+    pub fn display_url(&self) -> String {
+        self.url.to_string().trim_end_matches('/').to_string()
+    }
+
+    pub fn request_url(
+        &self,
+        request_path: &str,
+        query: Option<&str>,
+    ) -> Result<Url, TargetPolicyError> {
+        let mut target = self.url.clone();
+        let base_path = self.url.path().trim_end_matches('/');
+        let request_path = request_path.trim_start_matches('/');
+        let combined = if request_path.is_empty() {
+            normalized_path(base_path)
+        } else if base_path.is_empty() || base_path == "/" {
+            format!("/{request_path}")
+        } else {
+            format!("{base_path}/{request_path}")
+        };
+
+        target.set_path(&combined);
+        let scoped_base_path = normalized_path(base_path);
+        if !path_is_within_base(target.path(), &scoped_base_path) {
+            return Err(TargetPolicyError::new(
+                "target_path_escape",
+                "Forwarded request path must remain within the configured target path",
+            ));
+        }
+        target.set_query(query.filter(|value| !value.is_empty()));
+        target.set_fragment(None);
+        Ok(target)
+    }
+
+    pub fn http_client(&self) -> Result<Client, TargetPolicyError> {
+        self.http_client_with_timeout(Duration::from_secs(30))
+    }
+
+    pub fn http_client_with_timeout(&self, timeout: Duration) -> Result<Client, TargetPolicyError> {
+        Client::builder()
+            .timeout(timeout)
+            .redirect(Policy::none())
+            .no_proxy()
+            .danger_accept_invalid_certs(self.insecure_tls)
+            .resolve_to_addrs(&self.host, &self.pinned_addresses)
+            .build()
+            .map_err(|error| {
+                TargetPolicyError::new(
+                    "target_client_failed",
+                    format!("Failed to build pinned target client: {error}"),
+                )
+            })
+    }
+}
+
+fn normalized_path(path: &str) -> String {
+    if path.is_empty() {
+        "/".to_string()
+    } else {
+        path.to_string()
+    }
+}
+
+fn path_is_within_base(path: &str, base_path: &str) -> bool {
+    base_path == "/"
+        || path == base_path
+        || path
+            .strip_prefix(base_path)
+            .is_some_and(|suffix| suffix.starts_with('/'))
+}
+
+fn forbidden_address(address: IpAddr) -> bool {
+    address.is_unspecified()
+        || address.is_multicast()
+        || address == IpAddr::from([255, 255, 255, 255])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn rejects_query_fragment_credentials_and_non_http_schemes() {
+        for (target, code) in [
+            (
+                "http://localhost:3000/hooks?admin=true",
+                "target_query_forbidden",
+            ),
+            (
+                "http://localhost:3000/hooks#secret",
+                "target_fragment_forbidden",
+            ),
+            (
+                "http://user:pass@localhost:3000",
+                "target_credentials_forbidden",
+            ),
+            ("ftp://localhost:3000", "target_scheme_invalid"),
+        ] {
+            let error = TargetPolicy::resolve(target, false, false)
+                .await
+                .unwrap_err();
+            assert_eq!(error.code(), code);
+        }
+    }
+
+    #[tokio::test]
+    async fn requires_explicit_non_loopback_scope() {
+        let error = TargetPolicy::resolve("http://192.0.2.10:3000", false, false)
+            .await
+            .unwrap_err();
+        assert_eq!(error.code(), "target_non_loopback_requires_scope");
+
+        let target = TargetPolicy::resolve("http://192.0.2.10:3000", true, false)
+            .await
+            .unwrap();
+        assert!(target.plan().allow_non_loopback);
+    }
+
+    #[tokio::test]
+    async fn pins_loopback_and_builds_paths_without_changing_authority() {
+        let target = TargetPolicy::resolve("http://localhost:3000/base", false, false)
+            .await
+            .unwrap();
+        let plan = target.plan();
+        assert!(plan.pinned_addresses.iter().all(|address| {
+            address
+                .parse::<IpAddr>()
+                .map(|address| address.is_loopback())
+                .unwrap_or(false)
+        }));
+
+        let request = target
+            .request_url("//evil.example/admin", Some("a=1"))
+            .unwrap();
+        assert_eq!(request.host_str(), Some("localhost"));
+        assert_eq!(request.port(), Some(3000));
+        assert_eq!(request.path(), "/base/evil.example/admin");
+        assert_eq!(request.query(), Some("a=1"));
+    }
+
+    #[tokio::test]
+    async fn rejects_request_paths_that_escape_the_configured_base_path() {
+        let target = TargetPolicy::resolve("http://localhost:3000/base", false, false)
+            .await
+            .unwrap();
+
+        for path in ["../admin", "%2e%2e/admin", ".%2e/admin", "%2e./admin"] {
+            let error = target.request_url(path, None).unwrap_err();
+            assert_eq!(error.code(), "target_path_escape", "path: {path}");
+        }
+
+        assert_eq!(
+            target
+                .request_url("nested/../allowed", None)
+                .unwrap()
+                .path(),
+            "/base/allowed"
+        );
+    }
+
+    #[tokio::test]
+    async fn insecure_tls_is_explicit_and_https_only() {
+        let error = TargetPolicy::resolve("http://localhost:3000", false, true)
+            .await
+            .unwrap_err();
+        assert_eq!(error.code(), "target_insecure_tls_invalid");
+
+        let target = TargetPolicy::resolve("https://localhost:3443", false, true)
+            .await
+            .unwrap();
+        assert!(target.plan().insecure_tls);
+    }
+
+    #[tokio::test]
+    async fn pinned_client_does_not_follow_redirects() {
+        let mut server = mockito::Server::new_async().await;
+        let redirect = server
+            .mock("GET", "/start")
+            .with_status(302)
+            .with_header("location", "/unexpected")
+            .create_async()
+            .await;
+
+        let target = TargetPolicy::resolve(&server.url(), false, false)
+            .await
+            .unwrap();
+        let response = target
+            .http_client()
+            .unwrap()
+            .get(target.request_url("/start", None).unwrap())
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), reqwest::StatusCode::FOUND);
+        redirect.assert_async().await;
+    }
+}

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -22,6 +22,9 @@ use tokio_tungstenite::{
 };
 use tracing::{debug, error, info, warn};
 
+use crate::api;
+use crate::target_policy::TargetPolicy;
+
 type WsStream =
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
 type WsWrite = futures_util::stream::SplitSink<WsStream, Message>;
@@ -518,6 +521,7 @@ fn response_header_bytes(headers: &reqwest::header::HeaderMap) -> usize {
     })
 }
 
+#[cfg(test)]
 fn tunnel_http_client(timeout: Duration) -> Result<reqwest::Client> {
     reqwest::Client::builder()
         .timeout(timeout)
@@ -1266,9 +1270,9 @@ fn websocket_endpoint(base_url: &str, path: &str) -> String {
     )
 }
 
-/// Build a WebSocket URL from a base HTTP(S) URL.
-pub fn build_ws_url(base_url: &str, token: &str, path: &str) -> String {
-    format!("{}?token={token}", websocket_endpoint(base_url, path))
+/// Build a one-time ticket-authenticated WebSocket URL from a base HTTP(S) URL.
+pub fn build_ws_url(base_url: &str, ticket: &str, path: &str) -> String {
+    format!("{}?ticket={ticket}", websocket_endpoint(base_url, path))
 }
 
 fn redact_access_token(message: &str, access_token: &str) -> String {
@@ -1314,6 +1318,7 @@ pub fn is_fatal_error(error_msg: &str) -> bool {
         || lower.contains("forbidden")
         || lower.contains("401")
         || lower.contains("403")
+        || lower.contains("relay handshake rejected")
         || lower.contains("endpoint not found")
         || lower.contains("channel join failed")
         || lower.contains("static tunnel slug not found")
@@ -1346,7 +1351,7 @@ pub fn calculate_backoff(attempt: u32, config: &ReconnectConfig) -> Duration {
 pub struct TunnelClient {
     access_token_rx: watch::Receiver<String>,
     endpoint_slug: String,
-    target_url: String,
+    target: TargetPolicy,
     base_url: String,
     event_tx: mpsc::Sender<TunnelEvent>,
 }
@@ -1355,7 +1360,7 @@ impl TunnelClient {
     pub fn new(
         access_token_rx: watch::Receiver<String>,
         endpoint_slug: String,
-        target_url: String,
+        target: TargetPolicy,
         base_url: Option<String>,
         event_tx: mpsc::Sender<TunnelEvent>,
     ) -> Self {
@@ -1367,7 +1372,7 @@ impl TunnelClient {
         Self {
             access_token_rx,
             endpoint_slug,
-            target_url,
+            target,
             base_url,
             event_tx,
         }
@@ -1377,16 +1382,33 @@ impl TunnelClient {
     pub async fn connect_and_listen(&self) -> Result<()> {
         info!(
             endpoint = %self.endpoint_slug,
-            target = %self.target_url,
+            target = %self.target.display_url(),
             "Connecting to WebSocket tunnel"
         );
 
-        // Build WebSocket URL with auth token
+        // Exchange the long-lived HTTP credential for a one-time, scoped handshake ticket.
         let access_token = self.access_token_rx.borrow().clone();
-        let ws_url = build_ws_url(&self.base_url, &access_token, "socket/websocket");
+        let plan = serde_json::json!({
+            "mode": CAPTURE_FORWARD_MODE,
+            "route": {"endpoint_slug": &self.endpoint_slug},
+            "target": self.target.plan(),
+        });
+        let relay_ticket = api::issue_relay_ticket(&access_token, &self.base_url, &plan).await?;
+        if relay_ticket.scope != "relay:listen" {
+            return Err(anyhow!(
+                "Relay handshake rejected: ticket returned an incompatible scope"
+            ));
+        }
+        if relay_ticket.plan_fingerprint.is_empty() || relay_ticket.expires_at.is_empty() {
+            return Err(anyhow!(
+                "Relay handshake rejected: ticket receipt was incomplete"
+            ));
+        }
+
+        let ws_url = build_ws_url(&self.base_url, &relay_ticket.ticket, "cli-tunnel/websocket");
 
         debug!(
-            endpoint = %websocket_endpoint(&self.base_url, "socket/websocket"),
+            endpoint = %websocket_endpoint(&self.base_url, "cli-tunnel/websocket"),
             "Connecting to WebSocket"
         );
 
@@ -1429,7 +1451,8 @@ impl TunnelClient {
                     return Err(anyhow!(msg));
                 }
                 _ => {
-                    let detail = redact_access_token(&e.to_string(), &access_token);
+                    let detail = redact_access_token(&e.to_string(), &relay_ticket.ticket);
+                    let detail = redact_access_token(&detail, &access_token);
                     let msg = format!("Failed to connect to WebSocket: {detail}");
                     let _ = self
                         .event_tx
@@ -1696,32 +1719,25 @@ impl TunnelClient {
             "Forwarding webhook to local server"
         );
 
-        // Build target URL
-        let target = format!("{}{}", self.target_url, request.path);
+        let mut target_with_query = self.target.request_url(&request.path, None)?;
+        if !request.query_params.is_empty() {
+            let mut query = target_with_query.query_pairs_mut();
+            for (key, value) in &request.query_params {
+                query.append_pair(key, &json_value_to_string(value));
+            }
+        }
 
-        // Add query params if present
-        let target_with_query = if !request.query_params.is_empty() {
-            let query_string: Vec<String> = request
-                .query_params
-                .iter()
-                .map(|(k, v)| format!("{}={}", k, json_value_to_string(v)))
-                .collect();
-            format!("{}?{}", target, query_string.join("&"))
-        } else {
-            target
-        };
-
-        // Create HTTP client
-        let client = reqwest::Client::new();
+        // The client is pinned to the addresses resolved during activation and ignores proxies.
+        let client = self.target.http_client()?;
 
         // Build request with method
         let mut req_builder = match request.method.as_str() {
-            "GET" => client.get(&target_with_query),
-            "POST" => client.post(&target_with_query),
-            "PUT" => client.put(&target_with_query),
-            "DELETE" => client.delete(&target_with_query),
-            "PATCH" => client.patch(&target_with_query),
-            "HEAD" => client.head(&target_with_query),
+            "GET" => client.get(target_with_query.clone()),
+            "POST" => client.post(target_with_query.clone()),
+            "PUT" => client.put(target_with_query.clone()),
+            "DELETE" => client.delete(target_with_query.clone()),
+            "PATCH" => client.patch(target_with_query.clone()),
+            "HEAD" => client.head(target_with_query.clone()),
             _ => {
                 warn!("Unsupported HTTP method: {}", request.method);
                 return Ok(());
@@ -1761,7 +1777,7 @@ impl TunnelClient {
                     .event_tx
                     .send(TunnelEvent::ForwardSuccess {
                         request_id: request.id.clone(),
-                        target_url: target_with_query.clone(),
+                        target_url: target_with_query.to_string(),
                         status: status_code,
                         duration_ms,
                     })
@@ -1772,7 +1788,7 @@ impl TunnelClient {
                     serde_json::json!({
                         "request_id": &request.id,
                         "status": "proxied",
-                        "proxied_to": &target_with_query,
+                        "proxied_to": target_with_query.as_str(),
                         "status_code": status_code,
                         "response_headers": response_headers,
                         "response_body": response_body,
@@ -1799,7 +1815,7 @@ impl TunnelClient {
                     .event_tx
                     .send(TunnelEvent::ForwardError {
                         request_id: request.id.clone(),
-                        target_url: target_with_query.clone(),
+                        target_url: target_with_query.to_string(),
                         error: error_message.clone(),
                         duration_ms,
                     })
@@ -1810,7 +1826,7 @@ impl TunnelClient {
                     serde_json::json!({
                         "request_id": &request.id,
                         "status": "error",
-                        "proxied_to": &target_with_query,
+                        "proxied_to": target_with_query.as_str(),
                         "error": error_message,
                         "duration_ms": duration_ms,
                     }),
@@ -1914,6 +1930,7 @@ pub struct TunnelForwarder {
     access_token_rx: watch::Receiver<String>,
     local_host: String,
     local_port: u16,
+    target: TargetPolicy,
     org_id: Option<String>,
     slug: Option<String>,
     base_url: String,
@@ -1928,6 +1945,7 @@ impl TunnelForwarder {
         access_token_rx: watch::Receiver<String>,
         local_host: String,
         local_port: u16,
+        target: TargetPolicy,
         org_id: Option<String>,
         slug: Option<String>,
         event_tx: mpsc::Sender<TunnelEvent>,
@@ -1940,6 +1958,7 @@ impl TunnelForwarder {
             access_token_rx,
             local_host,
             local_port,
+            target,
             org_id,
             slug,
             base_url,
@@ -1976,9 +1995,26 @@ impl TunnelForwarder {
 
         let _ = self.event_tx.send(TunnelEvent::Connecting).await;
 
-        // Build WebSocket URL - connect to /tunnel/websocket endpoint (Phoenix default)
+        // Exchange the long-lived HTTP credential for a one-time, scoped handshake ticket.
         let access_token = self.access_token_rx.borrow().clone();
-        let ws_url = build_ws_url(&self.base_url, &access_token, "tunnel/websocket");
+        let plan = serde_json::json!({
+            "mode": DIRECT_RESPONSE_MODE,
+            "route": {"organization_id": &self.org_id, "slug": &self.slug},
+            "target": self.target.plan(),
+        });
+        let relay_ticket = api::issue_relay_ticket(&access_token, &self.base_url, &plan).await?;
+        if relay_ticket.scope != "relay:tunnel" {
+            return Err(anyhow!(
+                "Relay handshake rejected: ticket returned an incompatible scope"
+            ));
+        }
+        if relay_ticket.plan_fingerprint.is_empty() || relay_ticket.expires_at.is_empty() {
+            return Err(anyhow!(
+                "Relay handshake rejected: ticket receipt was incomplete"
+            ));
+        }
+
+        let ws_url = build_ws_url(&self.base_url, &relay_ticket.ticket, "tunnel/websocket");
 
         debug!(
             endpoint = %websocket_endpoint(&self.base_url, "tunnel/websocket"),
@@ -1995,7 +2031,8 @@ impl TunnelForwarder {
         {
             Ok(stream) => stream,
             Err(e) => {
-                let detail = redact_access_token(&e.to_string(), &access_token);
+                let detail = redact_access_token(&e.to_string(), &relay_ticket.ticket);
+                let detail = redact_access_token(&detail, &access_token);
                 let msg = format!("Failed to connect to tunnel: {detail}");
                 let _ = self
                     .event_tx
@@ -2700,11 +2737,23 @@ impl TunnelForwarder {
             "Forwarding tunnel request to local server"
         );
 
-        let mut target = format!("http://{}:{}{}", self.local_host, self.local_port, path);
-        if !query_string.is_empty() {
-            target.push('?');
-            target.push_str(&query_string);
-        }
+        let target = match self.target.request_url(
+            &path,
+            (!query_string.is_empty()).then_some(query_string.as_str()),
+        ) {
+            Ok(target) => target,
+            Err(error) => {
+                return self
+                    .report_tunnel_failure(
+                        &request_id,
+                        DeliveryFailure::known(error.code(), error.to_string()),
+                        &writer,
+                        &tunnel_topic,
+                        &phase,
+                    )
+                    .await;
+            }
+        };
 
         let remaining_ms = deadline_unix_ms.saturating_sub(unix_time_ms());
         if remaining_ms == 0 {
@@ -2722,8 +2771,12 @@ impl TunnelForwarder {
                 .await;
         }
 
-        // One end-to-end deadline covers local connection and response streaming.
-        let client = match tunnel_http_client(Duration::from_millis(remaining_ms)) {
+        // One end-to-end deadline covers a proxy-free, address-pinned local request
+        // and its response stream.
+        let client = match self
+            .target
+            .http_client_with_timeout(Duration::from_millis(remaining_ms))
+        {
             Ok(client) => client,
             Err(error) => {
                 return self
@@ -2758,7 +2811,7 @@ impl TunnelForwarder {
                     .await;
             }
         };
-        let mut req_builder = client.request(request_method, &target);
+        let mut req_builder = client.request(request_method, target);
 
         // reqwest sets request framing headers from the body actually sent.
         for (key, value) in headers {
@@ -3703,14 +3756,18 @@ mod tests {
         assert_eq!(cancellation_classification(DELIVERY_TERMINAL), None);
     }
 
-    #[test]
-    fn test_saturated_presentation_emits_stream_gap_after_recovery() {
+    #[tokio::test]
+    async fn test_saturated_presentation_emits_stream_gap_after_recovery() {
         let (_token_tx, token_rx) = watch::channel("token".to_string());
         let (event_tx, mut event_rx) = mpsc::channel(2);
+        let target = TargetPolicy::resolve("http://127.0.0.1:3000", false, false)
+            .await
+            .unwrap();
         let forwarder = TunnelForwarder::new(
             token_rx,
             "127.0.0.1".to_string(),
             3000,
+            target,
             None,
             None,
             event_tx,
@@ -3733,15 +3790,19 @@ mod tests {
         assert!(matches!(event_rx.try_recv(), Ok(TunnelEvent::Disconnected)));
     }
 
-    #[test]
-    fn test_closed_presentation_consumer_does_not_block_delivery_path() {
+    #[tokio::test]
+    async fn test_closed_presentation_consumer_does_not_block_delivery_path() {
         let (_token_tx, token_rx) = watch::channel("token".to_string());
         let (event_tx, event_rx) = mpsc::channel(1);
         drop(event_rx);
+        let target = TargetPolicy::resolve("http://127.0.0.1:3000", false, false)
+            .await
+            .unwrap();
         let forwarder = TunnelForwarder::new(
             token_rx,
             "127.0.0.1".to_string(),
             3000,
+            target,
             None,
             None,
             event_tx,
@@ -3880,10 +3941,18 @@ mod tests {
 
         let (_token_tx, token_rx) = watch::channel("token".to_string());
         let (event_tx, mut event_rx) = mpsc::channel(PRESENTATION_QUEUE_CAPACITY);
+        let target = TargetPolicy::resolve(
+            &format!("http://127.0.0.1:{}", local_address.port()),
+            false,
+            false,
+        )
+        .await
+        .unwrap();
         let forwarder = TunnelForwarder::new(
             token_rx,
             "127.0.0.1".to_string(),
             local_address.port(),
+            target,
             None,
             None,
             event_tx,
@@ -3997,13 +4066,13 @@ mod tests {
     #[test]
     fn test_build_ws_url_https_to_wss() {
         let url = build_ws_url("https://api.example.com", "tok123", "socket/websocket");
-        assert_eq!(url, "wss://api.example.com/socket/websocket?token=tok123");
+        assert_eq!(url, "wss://api.example.com/socket/websocket?ticket=tok123");
     }
 
     #[test]
     fn test_build_ws_url_http_to_ws() {
         let url = build_ws_url("http://localhost:4000", "tok", "tunnel/websocket");
-        assert_eq!(url, "ws://localhost:4000/tunnel/websocket?token=tok");
+        assert_eq!(url, "ws://localhost:4000/tunnel/websocket?ticket=tok");
     }
 
     #[test]
@@ -4059,6 +4128,19 @@ mod tests {
     #[test]
     fn test_is_fatal_error_join_failed() {
         assert!(is_fatal_error("Channel join failed: unknown"));
+    }
+
+    #[test]
+    fn test_relay_handshake_rejections_are_fatal() {
+        assert!(is_fatal_error(
+            "Relay handshake rejected (HTTP 401 Unauthorized): expired"
+        ));
+        assert!(is_fatal_error(
+            "Relay handshake rejected: ticket receipt was incomplete"
+        ));
+        assert!(!is_fatal_error(
+            "Relay handshake ticket request failed (HTTP 503 Service Unavailable)"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- exchange long-lived access tokens for short-lived, one-time relay handshake tickets
- parse targets as structured HTTP(S) URLs and reject credentials, query strings, and fragments
- pin activation-time DNS addresses while disabling redirects and proxy environment use
- require explicit non-loopback and insecure-TLS flags and protect persisted credentials

## Dependencies

- stacked on #24 (LEM-214); merge #24 first
- companion service: https://github.com/lemonity-org/hooklistener_service/pull/146
- blocks LEM-218

## Verification

- cargo test --all-targets --all-features (241 passed)
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check

Refs LEM-222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added safer target URL handling with loopback-only defaults, DNS pinning, redirect blocking, proxy bypassing, and validation that rejects credentials/query strings/fragments.
  - Added `--allow-non-loopback` and `--insecure-tls` opt-ins.
  - Tunnel connections now use short-lived relay tickets instead of long-lived access tokens.
  - Updated token status output to show validity (“present, valid/expired”) without previews.
- **Security**
  - Config files are stored with restricted `0o600` permissions.
  - Diagnostic bundles now fully remove/redact refresh-token details.
- **Documentation**
  - Quick start updated to explain target resolution and restriction behavior for `hooklistener listen`.
- **Tests**
  - Added coverage for relay ticket requests and “permanent” error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->