### PR TITLE
feat(tunnel): isolate concurrent relay delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ hooklistener --json listen <endpoint-slug>
 hooklistener --json tunnel --port 3000
 ```
 
+Tunnel delivery is independent from terminal rendering. If a slow or stalled consumer fills the presentation queue, the CLI continues reading requests and returning local responses, then emits a recoverable `stream_gap` event with the number of presentation events omitted. Treat the displayed request history as incomplete after a gap; delivery itself is unaffected.
+
+The relay runtime admits at most 8 local requests and 64 MiB of retained request bodies at once. Inbound streams, buffered local responses, and the serialized WebSocket writer have separate count and byte ceilings. Requests rejected before the local connection begins report `known_not_executed`; cancellations or failures after forwarding begins report `outcome_unknown`.
+
 Runtime errors use a consistent envelope:
 
 ```json

--- a/fixtures/tunnel_framing_v2.json
+++ b/fixtures/tunnel_framing_v2.json
@@ -1,0 +1,19 @@
+{
+  "version": 2,
+  "transport": "framed",
+  "frame_encoding": "base64url",
+  "max_frame_bytes": 65536,
+  "max_raw_chunk_bytes": 47000,
+  "queue_depth_frames": 1,
+  "backpressure": "per_frame_ack",
+  "sample_payload": {
+    "request_id": "22222222-2222-4222-8222-222222222222",
+    "headers": [
+      ["x-repeated", "first"],
+      ["x-repeated", "second"],
+      ["content-type", "application/octet-stream"]
+    ],
+    "body": "AP9iaW4",
+    "body_encoding": "base64"
+  }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1231,6 +1231,16 @@ fn tunnel_event_receipt(
                 serde_json::json!(["Check that the local target is running and reachable."]);
             receipt
         }
+        TunnelEvent::StreamGap { dropped_events } => {
+            let mut receipt = tunnel_event_base("stream_gap", "recoverable");
+            receipt["resource_uri"] = serde_json::json!(tunnel_session_resource_uri(host, port));
+            receipt["dropped_events"] = serde_json::json!(dropped_events);
+            receipt["delivery_affected"] = serde_json::json!(false);
+            receipt["next_actions"] = serde_json::json!([
+                "Treat the request presentation stream as incomplete; relay responses remain active."
+            ]);
+            receipt
+        }
         TunnelEvent::ConnectionError(error) => {
             let mut receipt = tunnel_event_base("connection_error", "error");
             receipt["resource_uri"] = serde_json::json!(tunnel_session_resource_uri(host, port));
@@ -1568,7 +1578,7 @@ async fn run_listen_json(
         endpoint.as_ref(),
     ))?;
 
-    let (event_tx, event_rx) = mpsc::channel(100);
+    let (event_tx, event_rx) = mpsc::channel(tunnel::PRESENTATION_QUEUE_CAPACITY);
     let tunnel_client = tunnel::TunnelClient::new(
         access_token_rx,
         endpoint_slug.clone(),
@@ -1648,7 +1658,7 @@ async fn run_tunnel_json(
         slug.as_deref(),
     ))?;
 
-    let (event_tx, event_rx) = mpsc::channel(100);
+    let (event_tx, event_rx) = mpsc::channel(tunnel::PRESENTATION_QUEUE_CAPACITY);
     tokio::spawn(run_tunnel_forwarder_connection(
         access_token_rx,
         host.clone(),
@@ -1775,7 +1785,7 @@ async fn run(cli: Cli) -> Result<()> {
                 app.listening_target = target.clone();
 
                 // Create channel for tunnel events
-                let (event_tx, event_rx) = mpsc::channel(100);
+                let (event_tx, event_rx) = mpsc::channel(tunnel::PRESENTATION_QUEUE_CAPACITY);
 
                 // Create and spawn tunnel client
                 let tunnel_client = tunnel::TunnelClient::new(
@@ -2862,7 +2872,7 @@ async fn run(cli: Cli) -> Result<()> {
                 app.tunnel_requested_slug = slug.clone();
 
                 // Create channel for tunnel events
-                let (event_tx, event_rx) = mpsc::channel(100);
+                let (event_tx, event_rx) = mpsc::channel(tunnel::PRESENTATION_QUEUE_CAPACITY);
 
                 // Create and spawn tunnel forwarder manager
                 let reconnect_tx = spawn_tunnel_forwarder_manager(
@@ -4285,6 +4295,14 @@ where
                     }
                     app.tunnel_stats.failed += 1;
                 }
+                TunnelEvent::StreamGap { dropped_events } => {
+                    app.set_tunnel_feedback(
+                        FeedbackKind::Warning,
+                        format!(
+                            "Presentation skipped {dropped_events} event(s); relay delivery is unaffected"
+                        ),
+                    );
+                }
                 TunnelEvent::ReplayCompleted {
                     request_id,
                     status,
@@ -5336,6 +5354,17 @@ mod tests {
         );
         assert_eq!(receipt["body_size"], 11);
         assert_eq!(receipt["headers"]["content-type"], "application/json");
+    }
+
+    #[test]
+    fn tunnel_stream_gap_is_recoverable_and_does_not_affect_delivery() {
+        let event = TunnelEvent::StreamGap { dropped_events: 7 };
+        let receipt = tunnel_event_receipt(&event, "127.0.0.1", 8080, None, None);
+
+        assert_eq!(receipt["event"], "stream_gap");
+        assert_eq!(receipt["status"], "recoverable");
+        assert_eq!(receipt["dropped_events"], 7);
+        assert_eq!(receipt["delivery_affected"], false);
     }
 
     #[test]

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -3,11 +3,18 @@ use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::{
+    Arc,
+    atomic::{AtomicU8, AtomicUsize, Ordering},
+};
 use std::time::{Duration, SystemTime};
-use tokio::sync::{mpsc, watch};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc, watch};
+use tokio::task::{AbortHandle, JoinSet};
 use tokio_tungstenite::{
     connect_async, connect_async_with_config,
-    tungstenite::{Message, error::Error as WsError, http::StatusCode, protocol::WebSocketConfig},
+    tungstenite::{
+        Bytes, Message, error::Error as WsError, http::StatusCode, protocol::WebSocketConfig,
+    },
 };
 use tracing::{debug, error, info, warn};
 
@@ -26,6 +33,300 @@ const LEGACY_MAX_RESPONSE_BODY_BYTES: usize = 7_000_000;
 const LEGACY_MAX_RESPONSE_HEADER_BYTES: usize = 1_048_576;
 const MAX_RAW_BODY_BYTES: usize = 1_048_576;
 const UI_BODY_PREVIEW_BYTES: usize = 65_536;
+const LOCAL_WORK_MAX_COUNT: usize = 8;
+const LOCAL_WORK_MAX_BYTES: usize = 64 * 1024 * 1024;
+const INBOUND_STREAM_MAX_COUNT: usize = 16;
+const INBOUND_STREAM_MAX_BYTES: usize = 64 * 1024 * 1024;
+const RESPONSE_BUFFER_MAX_BYTES: usize = 64 * 1024 * 1024;
+const OUTBOUND_CONTROL_MAX_COUNT: usize = 256;
+const OUTBOUND_RESPONSE_MAX_COUNT: usize = 256;
+const OUTBOUND_MAX_BYTES: usize = 4 * 1024 * 1024;
+pub const PRESENTATION_QUEUE_CAPACITY: usize = 100;
+const PRESENTATION_MAX_EVENT_BYTES: usize = 256 * 1024;
+
+const DELIVERY_QUEUED: u8 = 0;
+const DELIVERY_STARTED: u8 = 1;
+const DELIVERY_TERMINAL: u8 = 2;
+
+struct OutboundItem {
+    message: Message,
+    _bytes: OwnedSemaphorePermit,
+}
+
+#[derive(Clone)]
+struct PriorityWriter {
+    control_tx: mpsc::Sender<OutboundItem>,
+    response_tx: mpsc::Sender<OutboundItem>,
+    bytes: Arc<Semaphore>,
+}
+
+impl PriorityWriter {
+    fn spawn(write: WsWrite) -> (Self, tokio::task::JoinHandle<Result<()>>) {
+        let (control_tx, control_rx) = mpsc::channel(OUTBOUND_CONTROL_MAX_COUNT);
+        let (response_tx, response_rx) = mpsc::channel(OUTBOUND_RESPONSE_MAX_COUNT);
+        let writer = Self {
+            control_tx,
+            response_tx,
+            bytes: Arc::new(Semaphore::new(OUTBOUND_MAX_BYTES)),
+        };
+        let task = tokio::spawn(run_priority_writer(write, control_rx, response_rx));
+        (writer, task)
+    }
+
+    async fn control(&self, message: ChannelMessage) -> Result<()> {
+        self.enqueue_channel(message, true).await
+    }
+
+    async fn response(&self, message: ChannelMessage) -> Result<()> {
+        self.enqueue_channel(message, false).await
+    }
+
+    async fn pong(&self, data: Bytes) -> Result<()> {
+        self.enqueue(Message::Pong(data), true).await
+    }
+
+    async fn enqueue_channel(&self, message: ChannelMessage, control: bool) -> Result<()> {
+        let json = serde_json::to_vec(&message)?;
+        if json.len() > TUNNEL_MAX_FRAME_BYTES {
+            return Err(anyhow!("Tunnel channel message exceeds 64 KiB"));
+        }
+        self.enqueue(Message::Text(String::from_utf8(json)?.into()), control)
+            .await
+    }
+
+    async fn enqueue(&self, message: Message, control: bool) -> Result<()> {
+        let size = message.len().max(1);
+        let permits: u32 = size
+            .try_into()
+            .map_err(|_| anyhow!("Outbound message byte count is invalid"))?;
+        let bytes = self.bytes.clone().acquire_many_owned(permits).await?;
+        let item = OutboundItem {
+            message,
+            _bytes: bytes,
+        };
+        let sender = if control {
+            &self.control_tx
+        } else {
+            &self.response_tx
+        };
+        sender
+            .send(item)
+            .await
+            .map_err(|_| anyhow!("Tunnel writer stopped"))
+    }
+
+    #[cfg(test)]
+    fn available_bytes(&self) -> usize {
+        self.bytes.available_permits()
+    }
+}
+
+async fn run_priority_writer(
+    mut write: WsWrite,
+    mut control_rx: mpsc::Receiver<OutboundItem>,
+    mut response_rx: mpsc::Receiver<OutboundItem>,
+) -> Result<()> {
+    loop {
+        let item = tokio::select! {
+            biased;
+            item = control_rx.recv() => item,
+            item = response_rx.recv() => item,
+            else => None,
+        };
+
+        match item {
+            Some(item) => write.send(item.message).await?,
+            None => return Ok(()),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct LocalWorkBudget {
+    count: Arc<Semaphore>,
+    bytes: Arc<Semaphore>,
+}
+
+struct LocalWorkPermit {
+    _count: OwnedSemaphorePermit,
+    _bytes: OwnedSemaphorePermit,
+}
+
+#[derive(Clone)]
+struct ResponseBufferBudget {
+    bytes: Arc<Semaphore>,
+}
+
+impl ResponseBufferBudget {
+    fn new() -> Self {
+        Self {
+            bytes: Arc::new(Semaphore::new(RESPONSE_BUFFER_MAX_BYTES)),
+        }
+    }
+
+    fn try_acquire(&self, bytes: usize) -> Option<OwnedSemaphorePermit> {
+        let bytes: u32 = bytes.max(1).try_into().ok()?;
+        self.bytes.clone().try_acquire_many_owned(bytes).ok()
+    }
+
+    #[cfg(test)]
+    fn available_bytes(&self) -> usize {
+        self.bytes.available_permits()
+    }
+}
+
+impl LocalWorkBudget {
+    fn new() -> Self {
+        Self {
+            count: Arc::new(Semaphore::new(LOCAL_WORK_MAX_COUNT)),
+            bytes: Arc::new(Semaphore::new(LOCAL_WORK_MAX_BYTES)),
+        }
+    }
+
+    fn try_acquire(&self, bytes: usize) -> Option<LocalWorkPermit> {
+        let bytes: u32 = bytes.max(1).try_into().ok()?;
+        let count = self.count.clone().try_acquire_owned().ok()?;
+        let bytes = self.bytes.clone().try_acquire_many_owned(bytes).ok()?;
+        Some(LocalWorkPermit {
+            _count: count,
+            _bytes: bytes,
+        })
+    }
+
+    #[cfg(test)]
+    fn available_count(&self) -> usize {
+        self.count.available_permits()
+    }
+
+    #[cfg(test)]
+    fn available_bytes(&self) -> usize {
+        self.bytes.available_permits()
+    }
+}
+
+struct ActiveDelivery {
+    abort: AbortHandle,
+    phase: Arc<AtomicU8>,
+}
+
+struct RelayRuntime {
+    inbound_streams: HashMap<String, TunnelStreamAssembler>,
+    inbound_reserved_bytes: usize,
+    work_budget: LocalWorkBudget,
+    response_budget: ResponseBufferBudget,
+    workers: JoinSet<(String, Result<()>)>,
+    active_deliveries: HashMap<String, ActiveDelivery>,
+}
+
+impl RelayRuntime {
+    fn new() -> Self {
+        Self {
+            inbound_streams: HashMap::new(),
+            inbound_reserved_bytes: 0,
+            work_budget: LocalWorkBudget::new(),
+            response_budget: ResponseBufferBudget::new(),
+            workers: JoinSet::new(),
+            active_deliveries: HashMap::new(),
+        }
+    }
+}
+
+struct LocalDelivery {
+    request_id: String,
+    method: String,
+    path: String,
+    query_string: String,
+    headers: Vec<(String, String)>,
+    body: Vec<u8>,
+    deadline_unix_ms: u64,
+}
+
+impl LocalDelivery {
+    fn retained_bytes(&self) -> usize {
+        self.body.len()
+            + self.method.len()
+            + self.path.len()
+            + self.query_string.len()
+            + self
+                .headers
+                .iter()
+                .map(|(name, value)| name.len() + value.len())
+                .sum::<usize>()
+    }
+
+    fn received_event(&self) -> TunnelEvent {
+        TunnelEvent::RequestReceived {
+            request_id: self.request_id.clone(),
+            method: self.method.clone(),
+            path: bounded_presentation_text(&self.path),
+            headers: bounded_presentation_headers(self.headers.iter().cloned()),
+            body: body_preview(&self.body),
+            query_string: bounded_presentation_text(&self.query_string),
+        }
+    }
+}
+
+fn stream_error_message(topic: &str, stream_id: &str, code: &str) -> ChannelMessage {
+    ChannelMessage {
+        topic: topic.to_string(),
+        event: "tunnel_stream_error".to_string(),
+        payload: serde_json::json!({"stream_id": stream_id, "code": code}),
+        reference: None,
+    }
+}
+
+fn delivery_error_message(
+    topic: &str,
+    request_id: &str,
+    code: &str,
+    outcome: &str,
+    error: &str,
+) -> ChannelMessage {
+    ChannelMessage {
+        topic: topic.to_string(),
+        event: "tunnel_error".to_string(),
+        payload: serde_json::json!({
+            "request_id": request_id,
+            "code": code,
+            "outcome": outcome,
+            "error": error,
+        }),
+        reference: None,
+    }
+}
+
+fn cancellation_classification(phase: u8) -> Option<(&'static str, &'static str)> {
+    match phase {
+        DELIVERY_QUEUED => Some(("cancelled_before_forward", "known_not_executed")),
+        DELIVERY_STARTED => Some(("cancelled_after_forward_started", "outcome_unknown")),
+        DELIVERY_TERMINAL => None,
+        _ => Some(("cancelled_after_forward_started", "outcome_unknown")),
+    }
+}
+
+struct DeliveryFailure {
+    code: &'static str,
+    outcome: &'static str,
+    error: String,
+}
+
+impl DeliveryFailure {
+    fn known(code: &'static str, error: impl Into<String>) -> Self {
+        Self {
+            code,
+            outcome: "known_not_executed",
+            error: error.into(),
+        }
+    }
+
+    fn unknown(code: &'static str, error: impl Into<String>) -> Self {
+        Self {
+            code,
+            outcome: "outcome_unknown",
+            error: error.into(),
+        }
+    }
+}
 
 #[derive(Clone, Copy, Debug)]
 struct TunnelLimits {
@@ -149,6 +450,39 @@ fn body_preview(bytes: &[u8]) -> Option<String> {
     }
 
     Some(preview)
+}
+
+fn bounded_presentation_headers<I>(headers: I) -> HashMap<String, String>
+where
+    I: IntoIterator<Item = (String, String)>,
+{
+    let mut retained = HashMap::new();
+    let mut bytes = 0usize;
+
+    for (name, value) in headers {
+        let pair_bytes = name.len().saturating_add(value.len());
+        if bytes.saturating_add(pair_bytes) > PRESENTATION_MAX_EVENT_BYTES / 2 {
+            break;
+        }
+        bytes += pair_bytes;
+        retained.insert(name, value);
+    }
+
+    retained
+}
+
+fn bounded_presentation_text(value: &str) -> String {
+    const MAX_TEXT_BYTES: usize = PRESENTATION_MAX_EVENT_BYTES / 8;
+
+    if value.len() <= MAX_TEXT_BYTES {
+        return value.to_string();
+    }
+
+    let mut end = MAX_TEXT_BYTES;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}… [truncated]", &value[..end])
 }
 
 fn with_forward_id(mut payload: serde_json::Value, forward_id: Option<&str>) -> serde_json::Value {
@@ -433,18 +767,6 @@ fn ordered_header_pairs(value: Option<&serde_json::Value>) -> Result<Vec<(String
     }
 }
 
-async fn send_channel_message(write: &mut WsWrite, message: ChannelMessage) -> Result<()> {
-    let json = serde_json::to_vec(&message)?;
-    if json.len() > TUNNEL_MAX_FRAME_BYTES {
-        return Err(anyhow!("Tunnel channel message exceeds 64 KiB"));
-    }
-
-    write
-        .send(Message::Text(String::from_utf8(json)?.into()))
-        .await?;
-    Ok(())
-}
-
 fn validate_framing_contract(response: &serde_json::Value) -> Result<()> {
     let framing = response
         .get("framing")
@@ -550,6 +872,9 @@ pub enum TunnelEvent {
     RequestFailed {
         request_id: String,
         error: String,
+    },
+    StreamGap {
+        dropped_events: usize,
     },
     ReplayCompleted {
         request_id: String,
@@ -1237,6 +1562,7 @@ impl TunnelClient {
 }
 
 /// HTTP Tunnel forwarder - connects to /tunnel endpoint and forwards HTTP requests
+#[derive(Clone)]
 pub struct TunnelForwarder {
     access_token_rx: watch::Receiver<String>,
     local_host: String,
@@ -1245,6 +1571,7 @@ pub struct TunnelForwarder {
     slug: Option<String>,
     base_url: String,
     event_tx: mpsc::Sender<TunnelEvent>,
+    presentation_drops: Arc<AtomicUsize>,
 }
 
 impl TunnelForwarder {
@@ -1267,6 +1594,25 @@ impl TunnelForwarder {
             slug,
             base_url,
             event_tx,
+            presentation_drops: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn emit_presentation(&self, event: TunnelEvent) {
+        let dropped = self.presentation_drops.swap(0, Ordering::AcqRel);
+        if dropped > 0
+            && self
+                .event_tx
+                .try_send(TunnelEvent::StreamGap {
+                    dropped_events: dropped,
+                })
+                .is_err()
+        {
+            self.presentation_drops.fetch_add(dropped, Ordering::AcqRel);
+        }
+
+        if self.event_tx.try_send(event).is_err() {
+            self.presentation_drops.fetch_add(1, Ordering::AcqRel);
         }
     }
 
@@ -1448,44 +1794,43 @@ impl TunnelForwarder {
             }
         }
 
-        // Track last ping time
-        let mut last_ping = tokio::time::Instant::now();
-        let ping_interval = Duration::from_secs(30);
+        let (writer, mut writer_task) = PriorityWriter::spawn(write);
+        let mut ping_interval = tokio::time::interval(Duration::from_secs(30));
+        ping_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        ping_interval.tick().await;
         let mut ping_counter = 2;
-        let mut inbound_streams = HashMap::new();
+        let mut runtime = RelayRuntime::new();
 
         // Listen for tunnel_request events
         loop {
-            // Check if we need to send a ping
-            if last_ping.elapsed() >= ping_interval {
-                let ping_msg = ChannelMessage {
-                    topic: tunnel_topic.clone(),
-                    event: "ping".to_string(),
-                    payload: serde_json::json!({}),
-                    reference: Some(ping_counter.to_string()),
-                };
-                ping_counter += 1;
-
-                if let Ok(json) = serde_json::to_string(&ping_msg)
-                    && let Err(e) = write.send(Message::Text(json.into())).await
-                {
-                    error!("Failed to send ping: {}", e);
-                    break;
+            tokio::select! {
+                biased;
+                writer_result = &mut writer_task => {
+                    match writer_result {
+                        Ok(Ok(())) => return Err(anyhow!("Tunnel writer stopped")),
+                        Ok(Err(error)) => return Err(error.context("Tunnel writer failed")),
+                        Err(error) => return Err(anyhow!("Tunnel writer task failed: {error}")),
+                    }
                 }
-                last_ping = tokio::time::Instant::now();
-            }
-
-            // Use timeout to allow ping checks
-            match tokio::time::timeout(Duration::from_millis(100), read.next()).await {
-                Ok(Some(msg)) => match msg {
+                _ = ping_interval.tick() => {
+                    writer.control(ChannelMessage {
+                        topic: tunnel_topic.clone(),
+                        event: "ping".to_string(),
+                        payload: serde_json::json!({}),
+                        reference: Some(ping_counter.to_string()),
+                    }).await?;
+                    ping_counter += 1;
+                },
+                maybe_msg = read.next() => match maybe_msg {
+                    Some(msg) => match msg {
                     Ok(Message::Text(text)) => {
                         if let Err(e) = self
                             .handle_tunnel_message(
                                 &text,
-                                &mut write,
+                                &writer,
                                 &tunnel_topic,
                                 tunnel_limits,
-                                &mut inbound_streams,
+                                &mut runtime,
                             )
                             .await
                         {
@@ -1494,12 +1839,11 @@ impl TunnelForwarder {
                     }
                     Ok(Message::Close(frame)) => {
                         info!("Tunnel WebSocket closed: {:?}", frame);
-                        let _ = self.event_tx.send(TunnelEvent::Disconnected).await;
+                        self.emit_presentation(TunnelEvent::Disconnected);
                         break;
                     }
                     Ok(Message::Ping(data)) => {
-                        debug!("Received ping, sending pong");
-                        if let Err(e) = write.send(Message::Pong(data)).await {
+                        if let Err(e) = writer.pong(data).await {
                             error!("Failed to send pong: {}", e);
                             break;
                         }
@@ -1516,34 +1860,44 @@ impl TunnelForwarder {
                             .await;
                         break;
                     }
-                },
-                Ok(None) => {
+                    },
+                    None => {
                     warn!("Tunnel WebSocket stream ended");
-                    let _ = self.event_tx.send(TunnelEvent::Disconnected).await;
+                    self.emit_presentation(TunnelEvent::Disconnected);
                     break;
-                }
-                Err(_) => {
-                    // Timeout - continue to check ping
-                    continue;
-                }
+                    }
+                },
+                completed = runtime.workers.join_next(), if !runtime.workers.is_empty() => {
+                    if let Some(result) = completed {
+                        match result {
+                            Ok((request_id, Ok(()))) => {
+                                runtime.active_deliveries.remove(&request_id);
+                            }
+                            Ok((request_id, Err(error))) => {
+                                runtime.active_deliveries.remove(&request_id);
+                                error!(request_id = %request_id, error = %error, "Local delivery task failed");
+                            }
+                            Err(error) if error.is_cancelled() => {}
+                            Err(error) => error!(error = %error, "Local delivery task panicked"),
+                        }
+                    }
+                },
             }
         }
 
+        runtime.workers.abort_all();
+        while runtime.workers.join_next().await.is_some() {}
+        writer_task.abort();
         Ok(())
     }
 
     async fn handle_tunnel_message(
         &self,
         text: &str,
-        write: &mut futures_util::stream::SplitSink<
-            tokio_tungstenite::WebSocketStream<
-                tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
-            >,
-            Message,
-        >,
+        writer: &PriorityWriter,
         tunnel_topic: &str,
         tunnel_limits: TunnelLimits,
-        inbound_streams: &mut HashMap<String, TunnelStreamAssembler>,
+        runtime: &mut RelayRuntime,
     ) -> Result<()> {
         let msg: ChannelMessage = serde_json::from_str(text)?;
 
@@ -1556,14 +1910,36 @@ impl TunnelForwarder {
         match msg.event.as_str() {
             "tunnel_stream_start" => {
                 let assembler = TunnelStreamAssembler::from_start(&msg.payload, "request")?;
-                if inbound_streams.len() >= 128 {
-                    return Err(anyhow!("Too many concurrent tunnel streams"));
+                if runtime.inbound_streams.len() >= INBOUND_STREAM_MAX_COUNT
+                    || runtime
+                        .inbound_reserved_bytes
+                        .saturating_add(assembler.total_bytes)
+                        > INBOUND_STREAM_MAX_BYTES
+                {
+                    writer
+                        .control(stream_error_message(
+                            tunnel_topic,
+                            &assembler.stream_id,
+                            "relay_inbound_overloaded",
+                        ))
+                        .await?;
+                    return Ok(());
                 }
-                if inbound_streams.contains_key(&assembler.stream_id) {
-                    return Err(anyhow!("Duplicate tunnel stream id"));
+                if runtime.inbound_streams.contains_key(&assembler.stream_id) {
+                    writer
+                        .control(stream_error_message(
+                            tunnel_topic,
+                            &assembler.stream_id,
+                            "duplicate_stream",
+                        ))
+                        .await?;
+                    return Ok(());
                 }
 
-                inbound_streams.insert(assembler.stream_id.clone(), assembler);
+                runtime.inbound_reserved_bytes += assembler.total_bytes;
+                runtime
+                    .inbound_streams
+                    .insert(assembler.stream_id.clone(), assembler);
             }
             "tunnel_stream_frame" => {
                 let stream_id = msg
@@ -1574,14 +1950,42 @@ impl TunnelForwarder {
                     .to_string();
                 let sequence = json_usize(&msg.payload, "sequence")?;
 
-                let completed = inbound_streams
-                    .get_mut(&stream_id)
-                    .ok_or_else(|| anyhow!("Tunnel frame references an unknown stream"))?
-                    .append(&msg.payload)?;
+                let completed = match runtime.inbound_streams.get_mut(&stream_id) {
+                    Some(assembler) => match assembler.append(&msg.payload) {
+                        Ok(completed) => completed,
+                        Err(error) => {
+                            let assembler = runtime
+                                .inbound_streams
+                                .remove(&stream_id)
+                                .expect("invalid stream must still be reserved");
+                            runtime.inbound_reserved_bytes = runtime
+                                .inbound_reserved_bytes
+                                .saturating_sub(assembler.total_bytes);
+                            writer
+                                .control(stream_error_message(
+                                    tunnel_topic,
+                                    &stream_id,
+                                    "invalid_stream_frame",
+                                ))
+                                .await?;
+                            warn!(stream_id, error = %error, "Rejected invalid tunnel frame");
+                            return Ok(());
+                        }
+                    },
+                    None => {
+                        writer
+                            .control(stream_error_message(
+                                tunnel_topic,
+                                &stream_id,
+                                "unknown_stream",
+                            ))
+                            .await?;
+                        return Ok(());
+                    }
+                };
 
-                send_channel_message(
-                    write,
-                    ChannelMessage {
+                writer
+                    .control(ChannelMessage {
                         topic: tunnel_topic.to_string(),
                         event: "tunnel_stream_ack".to_string(),
                         payload: serde_json::json!({
@@ -1589,31 +1993,140 @@ impl TunnelForwarder {
                             "sequence": sequence,
                         }),
                         reference: None,
-                    },
-                )
-                .await?;
+                    })
+                    .await?;
 
                 if let Some(payload) = completed {
-                    let assembler = inbound_streams
+                    let assembler = runtime
+                        .inbound_streams
                         .remove(&stream_id)
                         .ok_or_else(|| anyhow!("Completed tunnel stream disappeared"))?;
-                    self.handle_framed_tunnel_request(
+                    runtime.inbound_reserved_bytes = runtime
+                        .inbound_reserved_bytes
+                        .saturating_sub(assembler.total_bytes);
+
+                    let delivery = match self.parse_local_delivery(
                         &payload,
                         assembler.deadline_unix_ms,
-                        write,
-                        tunnel_topic,
                         tunnel_limits,
-                    )
-                    .await?;
+                    ) {
+                        Ok(delivery) => delivery,
+                        Err(error) => {
+                            let request_id = payload
+                                .get("request_id")
+                                .and_then(serde_json::Value::as_str)
+                                .unwrap_or(&stream_id);
+                            writer
+                                .control(delivery_error_message(
+                                    tunnel_topic,
+                                    request_id,
+                                    "invalid_relay_request",
+                                    "known_not_executed",
+                                    &error.to_string(),
+                                ))
+                                .await?;
+                            return Ok(());
+                        }
+                    };
+
+                    if runtime.active_deliveries.contains_key(&delivery.request_id) {
+                        writer
+                            .control(delivery_error_message(
+                                tunnel_topic,
+                                &delivery.request_id,
+                                "duplicate_delivery",
+                                "known_not_executed",
+                                "Delivery is already active",
+                            ))
+                            .await?;
+                        return Ok(());
+                    }
+
+                    let Some(permit) = runtime.work_budget.try_acquire(delivery.retained_bytes())
+                    else {
+                        writer
+                            .control(delivery_error_message(
+                                tunnel_topic,
+                                &delivery.request_id,
+                                "relay_overloaded_before_forward",
+                                "known_not_executed",
+                                "Local relay capacity is full",
+                            ))
+                            .await?;
+                        self.emit_presentation(TunnelEvent::RequestFailed {
+                            request_id: delivery.request_id,
+                            error: "Local relay capacity is full".to_string(),
+                        });
+                        return Ok(());
+                    };
+
+                    self.emit_presentation(delivery.received_event());
+                    let request_id = delivery.request_id.clone();
+                    let task_request_id = request_id.clone();
+                    let phase = Arc::new(AtomicU8::new(DELIVERY_QUEUED));
+                    let task_phase = phase.clone();
+                    let worker = self.clone();
+                    let task_writer = writer.clone();
+                    let task_response_budget = runtime.response_budget.clone();
+                    let topic = tunnel_topic.to_string();
+                    let abort = runtime.workers.spawn(async move {
+                        let _permit = permit;
+                        let result = worker
+                            .forward_tunnel_request(
+                                delivery,
+                                task_phase,
+                                task_writer,
+                                topic,
+                                tunnel_limits,
+                                task_response_budget,
+                            )
+                            .await;
+                        (task_request_id, result)
+                    });
+                    runtime
+                        .active_deliveries
+                        .insert(request_id, ActiveDelivery { abort, phase });
+                }
+            }
+            "tunnel_cancel" => {
+                let request_id = required_string(&msg.payload, "request_id")?;
+                if let Some(active) = runtime.active_deliveries.remove(&request_id) {
+                    let phase = active.phase.load(Ordering::Acquire);
+                    if let Some((code, outcome)) = cancellation_classification(phase) {
+                        active.abort.abort();
+                        writer
+                            .control(delivery_error_message(
+                                tunnel_topic,
+                                &request_id,
+                                code,
+                                outcome,
+                                "Delivery was cancelled",
+                            ))
+                            .await?;
+                        self.emit_presentation(TunnelEvent::RequestFailed {
+                            request_id,
+                            error: outcome.to_string(),
+                        });
+                    }
                 }
             }
             "tunnel_stream_error" => {
+                if let Some(stream_id) = msg
+                    .payload
+                    .get("stream_id")
+                    .and_then(serde_json::Value::as_str)
+                    && let Some(assembler) = runtime.inbound_streams.remove(stream_id)
+                {
+                    runtime.inbound_reserved_bytes = runtime
+                        .inbound_reserved_bytes
+                        .saturating_sub(assembler.total_bytes);
+                }
                 let code = msg
                     .payload
                     .get("code")
                     .and_then(serde_json::Value::as_str)
                     .unwrap_or("stream_error");
-                return Err(anyhow!("Tunnel stream failed: {code}"));
+                warn!(code, "Tunnel stream failed");
             }
             "phx_reply" => {
                 // Handle ping replies
@@ -1634,14 +2147,12 @@ impl TunnelForwarder {
         Ok(())
     }
 
-    async fn handle_framed_tunnel_request(
+    fn parse_local_delivery(
         &self,
         payload: &serde_json::Value,
         deadline_unix_ms: u64,
-        write: &mut WsWrite,
-        tunnel_topic: &str,
         tunnel_limits: TunnelLimits,
-    ) -> Result<()> {
+    ) -> Result<LocalDelivery> {
         let request_id = required_string(payload, "request_id")?;
         let method = required_string(payload, "method")?;
         let path = required_string(payload, "path")?;
@@ -1668,34 +2179,14 @@ impl TunnelForwarder {
         };
 
         if body.len() > tunnel_limits.max_request_body_bytes {
-            return self
-                .report_tunnel_failure(
-                    &request_id,
-                    format!(
-                        "Tunnel request body exceeds advertised limit ({} > {} bytes)",
-                        body.len(),
-                        tunnel_limits.max_request_body_bytes
-                    ),
-                    write,
-                    tunnel_topic,
-                )
-                .await;
+            return Err(anyhow!(
+                "Tunnel request body exceeds advertised limit ({} > {} bytes)",
+                body.len(),
+                tunnel_limits.max_request_body_bytes
+            ));
         }
 
-        let headers_map = headers.iter().cloned().collect();
-        let _ = self
-            .event_tx
-            .send(TunnelEvent::RequestReceived {
-                request_id: request_id.clone(),
-                method: method.clone(),
-                path: path.clone(),
-                headers: headers_map,
-                body: body_preview(&body),
-                query_string: query_string.clone(),
-            })
-            .await;
-
-        self.forward_tunnel_request(
+        Ok(LocalDelivery {
             request_id,
             method,
             path,
@@ -1703,27 +2194,27 @@ impl TunnelForwarder {
             headers,
             body,
             deadline_unix_ms,
-            write,
-            tunnel_topic,
-            tunnel_limits,
-        )
-        .await
+        })
     }
 
-    #[allow(clippy::too_many_arguments)]
     async fn forward_tunnel_request(
         &self,
-        request_id: String,
-        method: String,
-        path: String,
-        query_string: String,
-        headers: Vec<(String, String)>,
-        body: Vec<u8>,
-        deadline_unix_ms: u64,
-        write: &mut WsWrite,
-        tunnel_topic: &str,
+        delivery: LocalDelivery,
+        phase: Arc<AtomicU8>,
+        writer: PriorityWriter,
+        tunnel_topic: String,
         tunnel_limits: TunnelLimits,
+        response_budget: ResponseBufferBudget,
     ) -> Result<()> {
+        let LocalDelivery {
+            request_id,
+            method,
+            path,
+            query_string,
+            headers,
+            body,
+            deadline_unix_ms,
+        } = delivery;
         let start_time = tokio::time::Instant::now();
 
         info!(
@@ -1745,18 +2236,53 @@ impl TunnelForwarder {
             return self
                 .report_tunnel_failure(
                     &request_id,
-                    "deadline_exceeded".to_string(),
-                    write,
-                    tunnel_topic,
+                    DeliveryFailure::known(
+                        "deadline_exceeded_before_forward",
+                        "Delivery deadline elapsed before local forwarding",
+                    ),
+                    &writer,
+                    &tunnel_topic,
+                    &phase,
                 )
                 .await;
         }
 
         // One end-to-end deadline covers local connection and response streaming.
-        let client = tunnel_http_client(Duration::from_millis(remaining_ms))?;
+        let client = match tunnel_http_client(Duration::from_millis(remaining_ms)) {
+            Ok(client) => client,
+            Err(error) => {
+                return self
+                    .report_tunnel_failure(
+                        &request_id,
+                        DeliveryFailure::known(
+                            "local_client_error_before_forward",
+                            error.to_string(),
+                        ),
+                        &writer,
+                        &tunnel_topic,
+                        &phase,
+                    )
+                    .await;
+            }
+        };
 
-        let request_method = reqwest::Method::from_bytes(method.as_bytes())
-            .with_context(|| format!("Unsupported HTTP method: {method}"))?;
+        let request_method = match reqwest::Method::from_bytes(method.as_bytes()) {
+            Ok(method) => method,
+            Err(error) => {
+                return self
+                    .report_tunnel_failure(
+                        &request_id,
+                        DeliveryFailure::known(
+                            "invalid_method_before_forward",
+                            format!("Unsupported HTTP method {method}: {error}"),
+                        ),
+                        &writer,
+                        &tunnel_topic,
+                        &phase,
+                    )
+                    .await;
+            }
+        };
         let mut req_builder = client.request(request_method, &target);
 
         // Add headers. reqwest sets request framing headers from the body we actually send.
@@ -1774,6 +2300,10 @@ impl TunnelForwarder {
             req_builder = req_builder.body(body);
         }
 
+        // After this point the local server may have observed the request. Every
+        // failure must therefore report an unknown outcome.
+        phase.store(DELIVERY_STARTED, Ordering::Release);
+
         // Send request and handle response
         match req_builder.send().await {
             Ok(mut response) => {
@@ -1787,12 +2317,17 @@ impl TunnelForwarder {
                     );
 
                     return self
-                        .report_tunnel_failure(&request_id, error_msg, write, tunnel_topic)
+                        .report_tunnel_failure(
+                            &request_id,
+                            DeliveryFailure::unknown("response_headers_too_large", error_msg),
+                            &writer,
+                            &tunnel_topic,
+                            &phase,
+                        )
                         .await;
                 }
 
                 let response_header_pairs = response_headers_to_pairs(response.headers());
-                let response_headers = response_headers_to_map(response.headers());
 
                 if response
                     .content_length()
@@ -1804,7 +2339,13 @@ impl TunnelForwarder {
                     );
 
                     return self
-                        .report_tunnel_failure(&request_id, error_msg, write, tunnel_topic)
+                        .report_tunnel_failure(
+                            &request_id,
+                            DeliveryFailure::unknown("response_body_too_large", error_msg),
+                            &writer,
+                            &tunnel_topic,
+                            &phase,
+                        )
                         .await;
                 }
 
@@ -1814,6 +2355,7 @@ impl TunnelForwarder {
                     .unwrap_or(0)
                     .min(tunnel_limits.max_response_body_bytes);
                 let mut response_bytes = Vec::with_capacity(initial_capacity);
+                let mut response_permits = Vec::new();
 
                 loop {
                     match response.chunk().await {
@@ -1829,12 +2371,32 @@ impl TunnelForwarder {
                                 return self
                                     .report_tunnel_failure(
                                         &request_id,
-                                        error_msg,
-                                        write,
-                                        tunnel_topic,
+                                        DeliveryFailure::unknown(
+                                            "response_body_too_large",
+                                            error_msg,
+                                        ),
+                                        &writer,
+                                        &tunnel_topic,
+                                        &phase,
                                     )
                                     .await;
                             }
+
+                            let Some(permit) = response_budget.try_acquire(chunk.len()) else {
+                                return self
+                                    .report_tunnel_failure(
+                                        &request_id,
+                                        DeliveryFailure::unknown(
+                                            "relay_response_overloaded",
+                                            "Concurrent local responses exceed the relay buffer budget",
+                                        ),
+                                        &writer,
+                                        &tunnel_topic,
+                                        &phase,
+                                    )
+                                    .await;
+                            };
+                            response_permits.push(permit);
 
                             response_bytes.extend_from_slice(&chunk);
                         }
@@ -1843,7 +2405,13 @@ impl TunnelForwarder {
                             let error_msg = format!("Failed to read local response: {error}");
 
                             return self
-                                .report_tunnel_failure(&request_id, error_msg, write, tunnel_topic)
+                                .report_tunnel_failure(
+                                    &request_id,
+                                    DeliveryFailure::unknown("response_read_failed", error_msg),
+                                    &writer,
+                                    &tunnel_topic,
+                                    &phase,
+                                )
                                 .await;
                         }
                     }
@@ -1862,32 +2430,41 @@ impl TunnelForwarder {
                     "Request forwarded successfully"
                 );
 
-                // Notify UI
-                let _ = self
-                    .event_tx
-                    .send(TunnelEvent::RequestForwarded {
-                        request_id: request_id.clone(),
-                        status,
-                        duration_ms,
-                        response_headers: response_headers.clone(),
-                        response_body: response_body_preview,
-                    })
-                    .await;
+                if let Err(error) = self
+                    .send_framed_tunnel_response(
+                        &writer,
+                        &tunnel_topic,
+                        &request_id,
+                        deadline_unix_ms,
+                        serde_json::json!({
+                            "request_id": request_id.clone(),
+                            "status": status,
+                            "headers": response_header_pairs,
+                            "body": response_body,
+                            "body_encoding": body_encoding,
+                        }),
+                    )
+                    .await
+                {
+                    return self
+                        .report_tunnel_failure(
+                            &request_id,
+                            DeliveryFailure::unknown("response_delivery_failed", error.to_string()),
+                            &writer,
+                            &tunnel_topic,
+                            &phase,
+                        )
+                        .await;
+                }
 
-                self.send_framed_tunnel_response(
-                    write,
-                    tunnel_topic,
-                    &request_id,
-                    deadline_unix_ms,
-                    serde_json::json!({
-                        "request_id": request_id,
-                        "status": status,
-                        "headers": response_header_pairs,
-                        "body": response_body,
-                        "body_encoding": body_encoding,
-                    }),
-                )
-                .await?;
+                phase.store(DELIVERY_TERMINAL, Ordering::Release);
+                self.emit_presentation(TunnelEvent::RequestForwarded {
+                    request_id,
+                    status,
+                    duration_ms,
+                    response_headers: bounded_presentation_headers(response_header_pairs),
+                    response_body: response_body_preview,
+                });
             }
             Err(e) => {
                 let duration_ms = start_time.elapsed().as_millis() as u64;
@@ -1900,18 +2477,15 @@ impl TunnelForwarder {
                     "Request forwarding failed"
                 );
 
-                // Notify UI
-                let _ = self
-                    .event_tx
-                    .send(TunnelEvent::RequestFailed {
-                        request_id: request_id.clone(),
-                        error: error_msg.clone(),
-                    })
+                return self
+                    .report_tunnel_failure(
+                        &request_id,
+                        DeliveryFailure::unknown("local_forward_failed", error_msg),
+                        &writer,
+                        &tunnel_topic,
+                        &phase,
+                    )
                     .await;
-
-                // Send tunnel_error back to server
-                self.send_tunnel_error(&request_id, &error_msg, write, tunnel_topic)
-                    .await?;
             }
         }
 
@@ -1920,7 +2494,7 @@ impl TunnelForwarder {
 
     async fn send_framed_tunnel_response(
         &self,
-        write: &mut WsWrite,
+        writer: &PriorityWriter,
         tunnel_topic: &str,
         request_id: &str,
         deadline_unix_ms: u64,
@@ -1929,71 +2503,48 @@ impl TunnelForwarder {
         let mut stream =
             OutboundTunnelStream::new(request_id, "response", deadline_unix_ms, &payload)?;
 
-        send_channel_message(write, stream.start_message(tunnel_topic)).await?;
+        writer.response(stream.start_message(tunnel_topic)).await?;
 
         while let Some(frame) = stream.next_frame(tunnel_topic)? {
             if unix_time_ms() >= deadline_unix_ms {
                 return Err(anyhow!("deadline_exceeded"));
             }
 
-            // SinkExt::send waits for sink readiness, keeping the transport queue
-            // to one frame even when the service consumes slowly.
-            send_channel_message(write, frame).await?;
+            writer.response(frame).await?;
         }
 
-        Ok(())
-    }
-
-    async fn send_tunnel_error(
-        &self,
-        request_id: &str,
-        error: &str,
-        write: &mut futures_util::stream::SplitSink<
-            tokio_tungstenite::WebSocketStream<
-                tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
-            >,
-            Message,
-        >,
-        tunnel_topic: &str,
-    ) -> Result<()> {
-        let error_message = ChannelMessage {
-            topic: tunnel_topic.to_string(),
-            event: "tunnel_error".to_string(),
-            payload: serde_json::json!({
-                "request_id": request_id,
-                "error": error,
-            }),
-            reference: None,
-        };
-
-        let error_json = serde_json::to_string(&error_message)?;
-        write.send(Message::Text(error_json.into())).await?;
         Ok(())
     }
 
     async fn report_tunnel_failure(
         &self,
         request_id: &str,
-        error: String,
-        write: &mut futures_util::stream::SplitSink<
-            tokio_tungstenite::WebSocketStream<
-                tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
-            >,
-            Message,
-        >,
+        failure: DeliveryFailure,
+        writer: &PriorityWriter,
         tunnel_topic: &str,
+        phase: &AtomicU8,
     ) -> Result<()> {
-        error!(request_id = %request_id, error = %error, "Tunnel request failed");
+        let DeliveryFailure {
+            code,
+            outcome,
+            error,
+        } = failure;
+        phase.store(DELIVERY_TERMINAL, Ordering::Release);
+        error!(request_id = %request_id, code, outcome, error = %error, "Tunnel request failed");
 
-        let _ = self
-            .event_tx
-            .send(TunnelEvent::RequestFailed {
-                request_id: request_id.to_string(),
-                error: error.clone(),
-            })
-            .await;
+        self.emit_presentation(TunnelEvent::RequestFailed {
+            request_id: request_id.to_string(),
+            error: error.clone(),
+        });
 
-        self.send_tunnel_error(request_id, &error, write, tunnel_topic)
+        writer
+            .control(delivery_error_message(
+                tunnel_topic,
+                request_id,
+                code,
+                outcome,
+                &error,
+            ))
             .await
     }
 
@@ -2327,6 +2878,322 @@ mod tests {
         assert!(preview.len() <= UI_BODY_PREVIEW_BYTES + 64);
         assert!(preview.contains("truncated"));
         assert!(preview.contains(&(UI_BODY_PREVIEW_BYTES * 2).to_string()));
+    }
+
+    #[test]
+    fn test_local_work_budget_bounds_concurrent_ten_megabyte_deliveries() {
+        let budget = LocalWorkBudget::new();
+        let ten_mib = 10 * 1024 * 1024;
+        let mut permits = Vec::new();
+
+        for _ in 0..6 {
+            permits.push(budget.try_acquire(ten_mib).unwrap());
+        }
+
+        assert_eq!(budget.available_count(), LOCAL_WORK_MAX_COUNT - 6);
+        assert_eq!(budget.available_bytes(), 4 * 1024 * 1024);
+        assert!(budget.try_acquire(ten_mib).is_none());
+        assert_eq!(budget.available_count(), LOCAL_WORK_MAX_COUNT - 6);
+
+        permits.pop();
+        assert!(budget.try_acquire(ten_mib).is_some());
+    }
+
+    #[test]
+    fn test_local_work_budget_enforces_count_independently_of_bytes() {
+        let budget = LocalWorkBudget::new();
+        let permits = (0..LOCAL_WORK_MAX_COUNT)
+            .map(|_| budget.try_acquire(1).unwrap())
+            .collect::<Vec<_>>();
+
+        assert_eq!(budget.available_count(), 0);
+        assert!(budget.try_acquire(1).is_none());
+        assert!(budget.available_bytes() > LOCAL_WORK_MAX_BYTES - 1024);
+
+        drop(permits);
+        assert_eq!(budget.available_count(), LOCAL_WORK_MAX_COUNT);
+    }
+
+    #[test]
+    fn test_response_buffer_budget_bounds_concurrent_ten_megabyte_responses() {
+        let budget = ResponseBufferBudget::new();
+        let ten_mib = 10 * 1024 * 1024;
+        let permits = (0..6)
+            .map(|_| budget.try_acquire(ten_mib).unwrap())
+            .collect::<Vec<_>>();
+
+        assert_eq!(budget.available_bytes(), 4 * 1024 * 1024);
+        assert!(budget.try_acquire(ten_mib).is_none());
+
+        drop(permits);
+        assert_eq!(budget.available_bytes(), RESPONSE_BUFFER_MAX_BYTES);
+    }
+
+    #[test]
+    fn test_cancellation_classifies_execution_boundary() {
+        assert_eq!(
+            cancellation_classification(DELIVERY_QUEUED),
+            Some(("cancelled_before_forward", "known_not_executed"))
+        );
+        assert_eq!(
+            cancellation_classification(DELIVERY_STARTED),
+            Some(("cancelled_after_forward_started", "outcome_unknown"))
+        );
+        assert_eq!(cancellation_classification(DELIVERY_TERMINAL), None);
+    }
+
+    #[test]
+    fn test_saturated_presentation_emits_stream_gap_after_recovery() {
+        let (_token_tx, token_rx) = watch::channel("token".to_string());
+        let (event_tx, mut event_rx) = mpsc::channel(2);
+        let forwarder = TunnelForwarder::new(
+            token_rx,
+            "127.0.0.1".to_string(),
+            3000,
+            None,
+            None,
+            event_tx,
+        );
+
+        forwarder.emit_presentation(TunnelEvent::Connecting);
+        forwarder.emit_presentation(TunnelEvent::Connected);
+        forwarder.emit_presentation(TunnelEvent::Disconnected);
+
+        assert!(matches!(event_rx.try_recv(), Ok(TunnelEvent::Connecting)));
+        assert!(matches!(event_rx.try_recv(), Ok(TunnelEvent::Connected)));
+
+        forwarder.emit_presentation(TunnelEvent::Disconnected);
+
+        assert!(matches!(
+            event_rx.try_recv(),
+            Ok(TunnelEvent::StreamGap { dropped_events: 1 })
+        ));
+        assert!(matches!(event_rx.try_recv(), Ok(TunnelEvent::Disconnected)));
+    }
+
+    #[test]
+    fn test_closed_presentation_consumer_does_not_block_delivery_path() {
+        let (_token_tx, token_rx) = watch::channel("token".to_string());
+        let (event_tx, event_rx) = mpsc::channel(1);
+        drop(event_rx);
+        let forwarder = TunnelForwarder::new(
+            token_rx,
+            "127.0.0.1".to_string(),
+            3000,
+            None,
+            None,
+            event_tx,
+        );
+
+        forwarder.emit_presentation(TunnelEvent::Disconnected);
+
+        assert_eq!(forwarder.presentation_drops.load(Ordering::Acquire), 1);
+    }
+
+    #[tokio::test]
+    async fn test_interrupted_delivery_releases_local_work_capacity() {
+        let budget = LocalWorkBudget::new();
+        let permit = budget.try_acquire(10 * 1024 * 1024).unwrap();
+        let mut workers = JoinSet::new();
+        let abort = workers.spawn(async move {
+            let _permit = permit;
+            std::future::pending::<()>().await;
+        });
+
+        abort.abort();
+        assert!(
+            workers
+                .join_next()
+                .await
+                .unwrap()
+                .unwrap_err()
+                .is_cancelled()
+        );
+        assert_eq!(budget.available_count(), LOCAL_WORK_MAX_COUNT);
+        assert_eq!(budget.available_bytes(), LOCAL_WORK_MAX_BYTES);
+    }
+
+    #[tokio::test]
+    async fn test_priority_writer_sends_control_before_queued_response() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (socket, _) = listener.accept().await.unwrap();
+            let mut websocket = tokio_tungstenite::accept_async(socket).await.unwrap();
+            let mut events = Vec::new();
+            for _ in 0..2 {
+                let message = websocket.next().await.unwrap().unwrap();
+                let Message::Text(text) = message else {
+                    panic!("expected a text channel message");
+                };
+                let message: ChannelMessage = serde_json::from_str(&text).unwrap();
+                events.push(message.event);
+            }
+            events
+        });
+
+        let (websocket, _) = connect_async(format!("ws://{address}")).await.unwrap();
+        let (write, _) = websocket.split();
+        let (control_tx, control_rx) = mpsc::channel(OUTBOUND_CONTROL_MAX_COUNT);
+        let (response_tx, response_rx) = mpsc::channel(OUTBOUND_RESPONSE_MAX_COUNT);
+        let writer = PriorityWriter {
+            control_tx,
+            response_tx,
+            bytes: Arc::new(Semaphore::new(OUTBOUND_MAX_BYTES)),
+        };
+
+        writer
+            .response(ChannelMessage {
+                topic: "cli:tunnel:test".to_string(),
+                event: "response".to_string(),
+                payload: serde_json::json!({}),
+                reference: None,
+            })
+            .await
+            .unwrap();
+        writer
+            .control(ChannelMessage {
+                topic: "cli:tunnel:test".to_string(),
+                event: "control".to_string(),
+                payload: serde_json::json!({}),
+                reference: None,
+            })
+            .await
+            .unwrap();
+        assert!(writer.available_bytes() < OUTBOUND_MAX_BYTES);
+
+        let writer_task = tokio::spawn(run_priority_writer(write, control_rx, response_rx));
+        let events = server.await.unwrap();
+        assert_eq!(events, vec!["control", "response"]);
+
+        drop(writer);
+        writer_task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_slow_local_handler_does_not_delay_fast_delivery() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::sync::oneshot;
+
+        let local_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let local_address = local_listener.local_addr().unwrap();
+        let (slow_started_tx, slow_started_rx) = oneshot::channel();
+        let local_server = tokio::spawn(async move {
+            let mut slow_started_tx = Some(slow_started_tx);
+            let mut handlers = JoinSet::new();
+            for _ in 0..2 {
+                let (mut socket, _) = local_listener.accept().await.unwrap();
+                let mut request = [0_u8; 1024];
+                let read = socket.read(&mut request).await.unwrap();
+                let slow = String::from_utf8_lossy(&request[..read]).contains("GET /slow ");
+                if slow && let Some(sender) = slow_started_tx.take() {
+                    let _ = sender.send(());
+                }
+                handlers.spawn(async move {
+                    if slow {
+                        tokio::time::sleep(Duration::from_millis(250)).await;
+                    }
+                    socket
+                        .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
+                        .await
+                        .unwrap();
+                });
+            }
+            while handlers.join_next().await.is_some() {}
+        });
+
+        let websocket_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let websocket_address = websocket_listener.local_addr().unwrap();
+        let websocket_server = tokio::spawn(async move {
+            let (socket, _) = websocket_listener.accept().await.unwrap();
+            let mut websocket = tokio_tungstenite::accept_async(socket).await.unwrap();
+            while websocket.next().await.is_some() {}
+        });
+        let (websocket, _) = connect_async(format!("ws://{websocket_address}"))
+            .await
+            .unwrap();
+        let (write, read) = websocket.split();
+        let (writer, writer_task) = PriorityWriter::spawn(write);
+
+        let (_token_tx, token_rx) = watch::channel("token".to_string());
+        let (event_tx, mut event_rx) = mpsc::channel(PRESENTATION_QUEUE_CAPACITY);
+        let forwarder = TunnelForwarder::new(
+            token_rx,
+            "127.0.0.1".to_string(),
+            local_address.port(),
+            None,
+            None,
+            event_tx,
+        );
+        let limits = TunnelLimits {
+            max_request_body_bytes: 1024,
+            max_response_body_bytes: 1024,
+            max_response_header_bytes: 1024,
+        };
+        let response_budget = ResponseBufferBudget::new();
+        let delivery = |request_id: &str, path: &str| LocalDelivery {
+            request_id: request_id.to_string(),
+            method: "GET".to_string(),
+            path: path.to_string(),
+            query_string: String::new(),
+            headers: Vec::new(),
+            body: Vec::new(),
+            deadline_unix_ms: unix_time_ms() + 2_000,
+        };
+
+        let slow = tokio::spawn({
+            let forwarder = forwarder.clone();
+            let writer = writer.clone();
+            let response_budget = response_budget.clone();
+            async move {
+                forwarder
+                    .forward_tunnel_request(
+                        delivery("slow", "/slow"),
+                        Arc::new(AtomicU8::new(DELIVERY_QUEUED)),
+                        writer,
+                        "cli:tunnel:test".to_string(),
+                        limits,
+                        response_budget,
+                    )
+                    .await
+            }
+        });
+        slow_started_rx.await.unwrap();
+
+        let fast = tokio::spawn({
+            let forwarder = forwarder.clone();
+            let writer = writer.clone();
+            let response_budget = response_budget.clone();
+            async move {
+                forwarder
+                    .forward_tunnel_request(
+                        delivery("fast", "/fast"),
+                        Arc::new(AtomicU8::new(DELIVERY_QUEUED)),
+                        writer,
+                        "cli:tunnel:test".to_string(),
+                        limits,
+                        response_budget,
+                    )
+                    .await
+            }
+        });
+
+        let first = tokio::time::timeout(Duration::from_secs(1), event_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            first,
+            TunnelEvent::RequestForwarded { request_id, .. } if request_id == "fast"
+        ));
+
+        fast.await.unwrap().unwrap();
+        slow.await.unwrap().unwrap();
+        local_server.await.unwrap();
+        drop(writer);
+        drop(read);
+        writer_task.await.unwrap().unwrap();
+        websocket_server.abort();
     }
 
     // TunnelWebhookRequest tests

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -144,6 +144,46 @@ struct ChannelMessage {
     reference: Option<String>,
 }
 
+const DIRECT_RESPONSE_MODE: &str = "direct_response";
+const CAPTURE_FORWARD_MODE: &str = "capture_forward";
+
+fn listen_join_payload() -> serde_json::Value {
+    serde_json::json!({"mode": CAPTURE_FORWARD_MODE})
+}
+
+fn tunnel_join_payload(
+    local_port: u16,
+    organization_id: Option<&str>,
+    slug: Option<&str>,
+) -> serde_json::Value {
+    let mut payload = serde_json::json!({
+        "mode": DIRECT_RESPONSE_MODE,
+        "local_port": local_port,
+    });
+
+    if let Some(organization_id) = organization_id {
+        payload["organization_id"] = serde_json::Value::String(organization_id.to_string());
+    }
+
+    if let Some(slug) = slug {
+        payload["slug"] = serde_json::Value::String(slug.to_string());
+    }
+
+    payload
+}
+
+fn validate_join_mode(response: &serde_json::Value, expected: &str) -> Result<()> {
+    match response.get("mode").and_then(|mode| mode.as_str()) {
+        Some(mode) if mode == expected => Ok(()),
+        Some(mode) => Err(anyhow!(
+            "Server activated incompatible mode '{mode}' (expected '{expected}'); no requests were forwarded"
+        )),
+        None => Err(anyhow!(
+            "Server did not confirm activation mode '{expected}'; upgrade the Hooklistener service before retrying"
+        )),
+    }
+}
+
 /// Webhook request received from the server (Tunnel format)
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct TunnelWebhookRequest {
@@ -419,7 +459,7 @@ impl TunnelClient {
         let join_message = ChannelMessage {
             topic: channel_topic.clone(),
             event: "phx_join".to_string(),
-            payload: serde_json::json!({}),
+            payload: listen_join_payload(),
             reference: Some("1".to_string()),
         };
 
@@ -441,6 +481,22 @@ impl TunnelClient {
                             && let Some(status) = msg.payload.get("status")
                         {
                             if status == "ok" {
+                                let response = msg
+                                    .payload
+                                    .get("response")
+                                    .ok_or_else(|| anyhow!("Channel join response was missing"))?;
+
+                                if let Err(error) =
+                                    validate_join_mode(response, CAPTURE_FORWARD_MODE)
+                                {
+                                    let reason = error.to_string();
+                                    let _ = self
+                                        .event_tx
+                                        .send(TunnelEvent::ConnectionError(reason.clone()))
+                                        .await;
+                                    return Err(error);
+                                }
+
                                 let _ = self.event_tx.send(TunnelEvent::Connected).await;
                                 info!(channel = %channel_topic, "Joined channel");
                                 joined = true;
@@ -937,16 +993,13 @@ impl TunnelForwarder {
         let (mut write, mut read) = ws_stream.split();
 
         // Join the tunnel:connect channel with local_port, organization_id, and optional slug
-        let mut join_payload = serde_json::json!({
-            "local_port": self.local_port,
-        });
-
-        if let Some(org_id) = &self.org_id {
-            join_payload["organization_id"] = serde_json::Value::String(org_id.clone());
-        }
+        let join_payload = tunnel_join_payload(
+            self.local_port,
+            self.org_id.as_deref(),
+            self.slug.as_deref(),
+        );
 
         if let Some(slug) = &self.slug {
-            join_payload["slug"] = serde_json::Value::String(slug.clone());
             info!(slug = %slug, "Requesting static tunnel");
         }
 
@@ -984,6 +1037,17 @@ impl TunnelForwarder {
                             if status == "ok" {
                                 // Extract subdomain, tunnel_id, and static flag from response
                                 if let Some(response) = msg.payload.get("response") {
+                                    if let Err(error) =
+                                        validate_join_mode(response, DIRECT_RESPONSE_MODE)
+                                    {
+                                        let reason = error.to_string();
+                                        let _ = self
+                                            .event_tx
+                                            .send(TunnelEvent::ConnectionError(reason.clone()))
+                                            .await;
+                                        return Err(error);
+                                    }
+
                                     tunnel_limits = TunnelLimits::from_join_response(response);
                                     let subdomain = response
                                         .get("subdomain")
@@ -1648,6 +1712,41 @@ mod tests {
         let json = r#"{"topic":"t","event":"e","payload":{}}"#;
         let msg: ChannelMessage = serde_json::from_str(json).unwrap();
         assert!(msg.reference.is_none());
+    }
+
+    #[test]
+    fn test_join_payloads_select_explicit_activation_modes() {
+        assert_eq!(listen_join_payload()["mode"], CAPTURE_FORWARD_MODE);
+
+        let tunnel_payload = tunnel_join_payload(3000, Some("org-1"), Some("payments"));
+        assert_eq!(tunnel_payload["mode"], DIRECT_RESPONSE_MODE);
+        assert_eq!(tunnel_payload["local_port"], 3000);
+        assert_eq!(tunnel_payload["organization_id"], "org-1");
+        assert_eq!(tunnel_payload["slug"], "payments");
+    }
+
+    #[test]
+    fn test_join_mode_must_be_confirmed_by_server() {
+        assert!(
+            validate_join_mode(
+                &serde_json::json!({"mode": DIRECT_RESPONSE_MODE}),
+                DIRECT_RESPONSE_MODE
+            )
+            .is_ok()
+        );
+
+        let missing = validate_join_mode(&serde_json::json!({}), DIRECT_RESPONSE_MODE)
+            .unwrap_err()
+            .to_string();
+        assert!(missing.contains("did not confirm"));
+
+        let incompatible = validate_join_mode(
+            &serde_json::json!({"mode": CAPTURE_FORWARD_MODE}),
+            DIRECT_RESPONSE_MODE,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(incompatible.contains("incompatible mode"));
     }
 
     #[test]

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -18,6 +18,9 @@ type WsWrite = futures_util::stream::SplitSink<WsStream, Message>;
 // A 256 MiB body expands to about 342 MiB as unpadded base64. The remaining
 // space covers the Phoenix envelope and the advertised response-header limit.
 const TUNNEL_MAX_WEBSOCKET_MESSAGE_BYTES: usize = 402_653_184;
+const TUNNEL_PROTOCOL_VERSION: u64 = 2;
+const TUNNEL_MAX_FRAME_BYTES: usize = 65_536;
+const TUNNEL_MAX_RAW_CHUNK_BYTES: usize = 47_000;
 const LEGACY_MAX_REQUEST_BODY_BYTES: usize = 10_485_760;
 const LEGACY_MAX_RESPONSE_BODY_BYTES: usize = 7_000_000;
 const LEGACY_MAX_RESPONSE_HEADER_BYTES: usize = 1_048_576;
@@ -52,8 +55,8 @@ fn json_limit(limits: Option<&serde_json::Value>, key: &str) -> Option<usize> {
 
 fn tunnel_websocket_config() -> WebSocketConfig {
     WebSocketConfig::default()
-        .max_message_size(Some(TUNNEL_MAX_WEBSOCKET_MESSAGE_BYTES))
-        .max_frame_size(Some(TUNNEL_MAX_WEBSOCKET_MESSAGE_BYTES))
+        .max_message_size(Some(TUNNEL_MAX_FRAME_BYTES))
+        .max_frame_size(Some(TUNNEL_MAX_FRAME_BYTES))
 }
 
 /// Extract the string representation of a JSON value.
@@ -95,6 +98,20 @@ fn response_headers_to_map(headers: &reqwest::header::HeaderMap) -> HashMap<Stri
         .collect()
 }
 
+fn response_headers_to_pairs(headers: &reqwest::header::HeaderMap) -> Vec<(String, String)> {
+    headers
+        .keys()
+        .flat_map(|name| {
+            headers.get_all(name).iter().map(move |value| {
+                (
+                    name.as_str().to_string(),
+                    value.to_str().unwrap_or("").to_string(),
+                )
+            })
+        })
+        .collect()
+}
+
 fn encode_response_body(bytes: &[u8]) -> (String, &'static str) {
     if bytes.len() <= MAX_RAW_BODY_BYTES
         && let Ok(text) = std::str::from_utf8(bytes)
@@ -109,6 +126,14 @@ fn response_header_bytes(headers: &reqwest::header::HeaderMap) -> usize {
     headers.iter().fold(0usize, |total, (name, value)| {
         total.saturating_add(name.as_str().len() + value.as_bytes().len() + 4)
     })
+}
+
+fn tunnel_http_client(timeout: Duration) -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(timeout)
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .context("Failed to build local tunnel HTTP client")
 }
 
 fn body_preview(bytes: &[u8]) -> Option<String> {
@@ -147,6 +172,302 @@ struct ChannelMessage {
 const DIRECT_RESPONSE_MODE: &str = "direct_response";
 const CAPTURE_FORWARD_MODE: &str = "capture_forward";
 
+struct TunnelStreamAssembler {
+    stream_id: String,
+    direction: String,
+    deadline_unix_ms: u64,
+    total_bytes: usize,
+    frame_count: usize,
+    next_sequence: usize,
+    data: Vec<u8>,
+}
+
+impl TunnelStreamAssembler {
+    fn from_start(payload: &serde_json::Value, expected_direction: &str) -> Result<Self> {
+        let version = payload
+            .get("version")
+            .and_then(serde_json::Value::as_u64)
+            .ok_or_else(|| anyhow!("Framed stream is missing a protocol version"))?;
+        if version != TUNNEL_PROTOCOL_VERSION {
+            return Err(anyhow!("Unsupported tunnel framing version: {version}"));
+        }
+
+        let direction = payload
+            .get("direction")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| anyhow!("Framed stream is missing a direction"))?;
+        if direction != expected_direction {
+            return Err(anyhow!("Unexpected tunnel stream direction: {direction}"));
+        }
+
+        let stream_id = payload
+            .get("stream_id")
+            .and_then(serde_json::Value::as_str)
+            .filter(|stream_id| !stream_id.is_empty())
+            .ok_or_else(|| anyhow!("Framed stream is missing an id"))?
+            .to_string();
+        let total_bytes = json_usize(payload, "total_bytes")?;
+        if total_bytes > TUNNEL_MAX_WEBSOCKET_MESSAGE_BYTES {
+            return Err(anyhow!("Tunnel stream exceeds the advertised limit"));
+        }
+
+        let frame_count = json_usize(payload, "frame_count")?;
+        let expected_frame_count = total_bytes.div_ceil(TUNNEL_MAX_RAW_CHUNK_BYTES).max(1);
+        if frame_count != expected_frame_count {
+            return Err(anyhow!("Tunnel stream has an invalid frame count"));
+        }
+
+        let deadline_unix_ms = payload
+            .get("deadline_unix_ms")
+            .and_then(serde_json::Value::as_u64)
+            .ok_or_else(|| anyhow!("Framed stream is missing its deadline"))?;
+        if deadline_unix_ms <= unix_time_ms() {
+            return Err(anyhow!("Tunnel stream deadline has expired"));
+        }
+
+        Ok(Self {
+            stream_id,
+            direction: direction.to_string(),
+            deadline_unix_ms,
+            total_bytes,
+            frame_count,
+            next_sequence: 0,
+            data: Vec::new(),
+        })
+    }
+
+    fn append(&mut self, payload: &serde_json::Value) -> Result<Option<serde_json::Value>> {
+        if payload.get("version").and_then(serde_json::Value::as_u64)
+            != Some(TUNNEL_PROTOCOL_VERSION)
+            || payload.get("stream_id").and_then(serde_json::Value::as_str)
+                != Some(self.stream_id.as_str())
+            || payload.get("direction").and_then(serde_json::Value::as_str)
+                != Some(self.direction.as_str())
+        {
+            return Err(anyhow!("Tunnel frame does not match its stream"));
+        }
+
+        let sequence = json_usize(payload, "sequence")?;
+        if sequence != self.next_sequence {
+            return Err(anyhow!(
+                "Out-of-order tunnel frame: expected {}, got {sequence}",
+                self.next_sequence
+            ));
+        }
+
+        let encoded = payload
+            .get("data")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| anyhow!("Tunnel frame is missing data"))?;
+        let chunk = URL_SAFE_NO_PAD
+            .decode(encoded)
+            .context("Tunnel frame contains invalid base64url data")?;
+        if chunk.len() > TUNNEL_MAX_RAW_CHUNK_BYTES
+            || self.data.len().saturating_add(chunk.len()) > self.total_bytes
+        {
+            return Err(anyhow!("Tunnel frame exceeds the 64 KiB framing contract"));
+        }
+
+        self.data.extend_from_slice(&chunk);
+        self.next_sequence += 1;
+        let final_frame = payload
+            .get("final")
+            .and_then(serde_json::Value::as_bool)
+            .ok_or_else(|| anyhow!("Tunnel frame is missing its final marker"))?;
+
+        if final_frame {
+            if self.data.len() != self.total_bytes || self.next_sequence != self.frame_count {
+                return Err(anyhow!("Tunnel stream ended before all bytes arrived"));
+            }
+
+            return Ok(Some(
+                serde_json::from_slice(&self.data)
+                    .context("Tunnel stream contains invalid JSON")?,
+            ));
+        }
+
+        if self.data.len() == self.total_bytes {
+            return Err(anyhow!("Tunnel stream omitted its final marker"));
+        }
+
+        Ok(None)
+    }
+}
+
+struct OutboundTunnelStream {
+    stream_id: String,
+    direction: &'static str,
+    deadline_unix_ms: u64,
+    encoded: Vec<u8>,
+    offset: usize,
+    sequence: usize,
+    frame_count: usize,
+}
+
+impl OutboundTunnelStream {
+    fn new(
+        stream_id: &str,
+        direction: &'static str,
+        deadline_unix_ms: u64,
+        payload: &serde_json::Value,
+    ) -> Result<Self> {
+        let encoded = serde_json::to_vec(payload)?;
+        if encoded.len() > TUNNEL_MAX_WEBSOCKET_MESSAGE_BYTES {
+            return Err(anyhow!("Tunnel stream exceeds the advertised limit"));
+        }
+
+        let frame_count = encoded.len().div_ceil(TUNNEL_MAX_RAW_CHUNK_BYTES).max(1);
+        Ok(Self {
+            stream_id: stream_id.to_string(),
+            direction,
+            deadline_unix_ms,
+            encoded,
+            offset: 0,
+            sequence: 0,
+            frame_count,
+        })
+    }
+
+    fn start_message(&self, topic: &str) -> ChannelMessage {
+        ChannelMessage {
+            topic: topic.to_string(),
+            event: "tunnel_stream_start".to_string(),
+            payload: serde_json::json!({
+                "version": TUNNEL_PROTOCOL_VERSION,
+                "stream_id": self.stream_id,
+                "direction": self.direction,
+                "deadline_unix_ms": self.deadline_unix_ms,
+                "total_bytes": self.encoded.len(),
+                "frame_count": self.frame_count,
+                "frame_encoding": "base64url",
+            }),
+            reference: None,
+        }
+    }
+
+    fn next_frame(&mut self, topic: &str) -> Result<Option<ChannelMessage>> {
+        if self.offset == self.encoded.len() && self.sequence > 0 {
+            return Ok(None);
+        }
+
+        let end = self
+            .offset
+            .saturating_add(TUNNEL_MAX_RAW_CHUNK_BYTES)
+            .min(self.encoded.len());
+        let chunk = &self.encoded[self.offset..end];
+        let final_frame = end == self.encoded.len();
+        let message = ChannelMessage {
+            topic: topic.to_string(),
+            event: "tunnel_stream_frame".to_string(),
+            payload: serde_json::json!({
+                "version": TUNNEL_PROTOCOL_VERSION,
+                "stream_id": self.stream_id,
+                "direction": self.direction,
+                "sequence": self.sequence,
+                "final": final_frame,
+                "data": URL_SAFE_NO_PAD.encode(chunk),
+            }),
+            reference: None,
+        };
+
+        if serde_json::to_vec(&message)?.len() > TUNNEL_MAX_FRAME_BYTES {
+            return Err(anyhow!("Serialized tunnel frame exceeds 64 KiB"));
+        }
+
+        self.offset = end;
+        self.sequence += 1;
+        Ok(Some(message))
+    }
+}
+
+fn json_usize(payload: &serde_json::Value, key: &str) -> Result<usize> {
+    payload
+        .get(key)
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|value| value.try_into().ok())
+        .ok_or_else(|| anyhow!("Tunnel stream has invalid {key}"))
+}
+
+fn unix_time_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
+}
+
+fn required_string(payload: &serde_json::Value, key: &str) -> Result<String> {
+    payload
+        .get(key)
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| anyhow!("Tunnel request is missing {key}"))
+}
+
+fn ordered_header_pairs(value: Option<&serde_json::Value>) -> Result<Vec<(String, String)>> {
+    match value {
+        None => Ok(Vec::new()),
+        Some(serde_json::Value::Array(headers)) => headers
+            .iter()
+            .map(|header| {
+                let pair = header
+                    .as_array()
+                    .filter(|pair| pair.len() == 2)
+                    .ok_or_else(|| anyhow!("Tunnel header is not an ordered name/value pair"))?;
+                let name = pair[0]
+                    .as_str()
+                    .ok_or_else(|| anyhow!("Tunnel header name is not text"))?;
+                let value = pair[1]
+                    .as_str()
+                    .ok_or_else(|| anyhow!("Tunnel header value is not text"))?;
+                Ok((name.to_string(), value.to_string()))
+            })
+            .collect(),
+        Some(serde_json::Value::Object(headers)) => Ok(headers
+            .iter()
+            .map(|(name, value)| (name.clone(), json_value_to_string(value)))
+            .collect()),
+        Some(_) => Err(anyhow!("Tunnel headers have an unsupported shape")),
+    }
+}
+
+async fn send_channel_message(write: &mut WsWrite, message: ChannelMessage) -> Result<()> {
+    let json = serde_json::to_vec(&message)?;
+    if json.len() > TUNNEL_MAX_FRAME_BYTES {
+        return Err(anyhow!("Tunnel channel message exceeds 64 KiB"));
+    }
+
+    write
+        .send(Message::Text(String::from_utf8(json)?.into()))
+        .await?;
+    Ok(())
+}
+
+fn validate_framing_contract(response: &serde_json::Value) -> Result<()> {
+    let framing = response
+        .get("framing")
+        .ok_or_else(|| anyhow!("Server did not advertise bounded tunnel framing"))?;
+
+    if framing.get("version").and_then(serde_json::Value::as_u64) != Some(TUNNEL_PROTOCOL_VERSION)
+        || framing
+            .get("max_frame_bytes")
+            .and_then(serde_json::Value::as_u64)
+            != Some(TUNNEL_MAX_FRAME_BYTES as u64)
+        || framing
+            .get("queue_depth_frames")
+            .and_then(serde_json::Value::as_u64)
+            != Some(1)
+    {
+        return Err(anyhow!(
+            "Server advertised an incompatible framing contract"
+        ));
+    }
+
+    Ok(())
+}
+
 fn listen_join_payload() -> serde_json::Value {
     serde_json::json!({"mode": CAPTURE_FORWARD_MODE})
 }
@@ -158,6 +479,7 @@ fn tunnel_join_payload(
 ) -> serde_json::Value {
     let mut payload = serde_json::json!({
         "mode": DIRECT_RESPONSE_MODE,
+        "protocol_version": TUNNEL_PROTOCOL_VERSION,
         "local_port": local_port,
     });
 
@@ -1048,6 +1370,15 @@ impl TunnelForwarder {
                                         return Err(error);
                                     }
 
+                                    if let Err(error) = validate_framing_contract(response) {
+                                        let reason = error.to_string();
+                                        let _ = self
+                                            .event_tx
+                                            .send(TunnelEvent::ConnectionError(reason.clone()))
+                                            .await;
+                                        return Err(error);
+                                    }
+
                                     tunnel_limits = TunnelLimits::from_join_response(response);
                                     let subdomain = response
                                         .get("subdomain")
@@ -1121,6 +1452,7 @@ impl TunnelForwarder {
         let mut last_ping = tokio::time::Instant::now();
         let ping_interval = Duration::from_secs(30);
         let mut ping_counter = 2;
+        let mut inbound_streams = HashMap::new();
 
         // Listen for tunnel_request events
         loop {
@@ -1148,7 +1480,13 @@ impl TunnelForwarder {
                 Ok(Some(msg)) => match msg {
                     Ok(Message::Text(text)) => {
                         if let Err(e) = self
-                            .handle_tunnel_message(&text, &mut write, &tunnel_topic, tunnel_limits)
+                            .handle_tunnel_message(
+                                &text,
+                                &mut write,
+                                &tunnel_topic,
+                                tunnel_limits,
+                                &mut inbound_streams,
+                            )
                             .await
                         {
                             error!("Error handling tunnel message: {}", e);
@@ -1205,6 +1543,7 @@ impl TunnelForwarder {
         >,
         tunnel_topic: &str,
         tunnel_limits: TunnelLimits,
+        inbound_streams: &mut HashMap<String, TunnelStreamAssembler>,
     ) -> Result<()> {
         let msg: ChannelMessage = serde_json::from_str(text)?;
 
@@ -1215,104 +1554,66 @@ impl TunnelForwarder {
         );
 
         match msg.event.as_str() {
-            "tunnel_request" => {
-                // Extract request details
-                if let Some(payload) = msg.payload.as_object() {
-                    let request_id = payload
-                        .get("request_id")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("unknown")
-                        .to_string();
-                    let method = payload
-                        .get("method")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("GET")
-                        .to_string();
-                    let path = payload
-                        .get("path")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("/")
-                        .to_string();
-                    let query_string = payload
-                        .get("query_string")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    let headers = payload
-                        .get("headers")
-                        .and_then(|v| v.as_object())
-                        .cloned()
-                        .unwrap_or_default();
+            "tunnel_stream_start" => {
+                let assembler = TunnelStreamAssembler::from_start(&msg.payload, "request")?;
+                if inbound_streams.len() >= 128 {
+                    return Err(anyhow!("Too many concurrent tunnel streams"));
+                }
+                if inbound_streams.contains_key(&assembler.stream_id) {
+                    return Err(anyhow!("Duplicate tunnel stream id"));
+                }
 
-                    // Decode body based on body_encoding field
-                    let body_encoding = payload
-                        .get("body_encoding")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("raw");
-                    let raw_body = payload.get("body").and_then(|v| v.as_str()).unwrap_or("");
-                    let body: Vec<u8> = if body_encoding == "base64" {
-                        // Decode base64 body
-                        URL_SAFE_NO_PAD.decode(raw_body).unwrap_or_else(|e| {
-                            warn!("Failed to decode base64 body: {}", e);
-                            raw_body.as_bytes().to_vec()
-                        })
-                    } else {
-                        // Use body as-is (raw UTF-8)
-                        raw_body.as_bytes().to_vec()
-                    };
+                inbound_streams.insert(assembler.stream_id.clone(), assembler);
+            }
+            "tunnel_stream_frame" => {
+                let stream_id = msg
+                    .payload
+                    .get("stream_id")
+                    .and_then(serde_json::Value::as_str)
+                    .ok_or_else(|| anyhow!("Tunnel frame is missing its stream id"))?
+                    .to_string();
+                let sequence = json_usize(&msg.payload, "sequence")?;
 
-                    if body.len() > tunnel_limits.max_request_body_bytes {
-                        self.report_tunnel_failure(
-                            &request_id,
-                            format!(
-                                "Tunnel request body exceeds advertised limit ({} > {} bytes)",
-                                body.len(),
-                                tunnel_limits.max_request_body_bytes
-                            ),
-                            write,
-                            tunnel_topic,
-                        )
-                        .await?;
+                let completed = inbound_streams
+                    .get_mut(&stream_id)
+                    .ok_or_else(|| anyhow!("Tunnel frame references an unknown stream"))?
+                    .append(&msg.payload)?;
 
-                        return Ok(());
-                    }
+                send_channel_message(
+                    write,
+                    ChannelMessage {
+                        topic: tunnel_topic.to_string(),
+                        event: "tunnel_stream_ack".to_string(),
+                        payload: serde_json::json!({
+                            "stream_id": stream_id,
+                            "sequence": sequence,
+                        }),
+                        reference: None,
+                    },
+                )
+                .await?;
 
-                    // Convert headers Map<String, Value> → HashMap<String, String>
-                    let headers_map: HashMap<String, String> = headers
-                        .iter()
-                        .map(|(k, v)| (k.clone(), json_value_to_string(v)))
-                        .collect();
-
-                    // Keep the TUI history bounded while forwarding the complete body.
-                    let body_string = body_preview(&body);
-
-                    // Notify UI about request
-                    let _ = self
-                        .event_tx
-                        .send(TunnelEvent::RequestReceived {
-                            request_id: request_id.clone(),
-                            method: method.clone(),
-                            path: path.clone(),
-                            headers: headers_map,
-                            body: body_string,
-                            query_string: query_string.clone(),
-                        })
-                        .await;
-
-                    // Forward the request
-                    self.forward_tunnel_request(
-                        request_id,
-                        method,
-                        path,
-                        query_string,
-                        headers,
-                        body,
+                if let Some(payload) = completed {
+                    let assembler = inbound_streams
+                        .remove(&stream_id)
+                        .ok_or_else(|| anyhow!("Completed tunnel stream disappeared"))?;
+                    self.handle_framed_tunnel_request(
+                        &payload,
+                        assembler.deadline_unix_ms,
                         write,
                         tunnel_topic,
                         tunnel_limits,
                     )
                     .await?;
                 }
+            }
+            "tunnel_stream_error" => {
+                let code = msg
+                    .payload
+                    .get("code")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("stream_error");
+                return Err(anyhow!("Tunnel stream failed: {code}"));
             }
             "phx_reply" => {
                 // Handle ping replies
@@ -1333,6 +1634,82 @@ impl TunnelForwarder {
         Ok(())
     }
 
+    async fn handle_framed_tunnel_request(
+        &self,
+        payload: &serde_json::Value,
+        deadline_unix_ms: u64,
+        write: &mut WsWrite,
+        tunnel_topic: &str,
+        tunnel_limits: TunnelLimits,
+    ) -> Result<()> {
+        let request_id = required_string(payload, "request_id")?;
+        let method = required_string(payload, "method")?;
+        let path = required_string(payload, "path")?;
+        let query_string = payload
+            .get("query_string")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        let headers = ordered_header_pairs(payload.get("headers"))?;
+        let body_encoding = payload
+            .get("body_encoding")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("raw");
+        let raw_body = payload
+            .get("body")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("");
+        let body = match body_encoding {
+            "raw" => raw_body.as_bytes().to_vec(),
+            "base64" => URL_SAFE_NO_PAD
+                .decode(raw_body)
+                .context("Tunnel request contains invalid base64url body data")?,
+            encoding => return Err(anyhow!("Unsupported tunnel body encoding: {encoding}")),
+        };
+
+        if body.len() > tunnel_limits.max_request_body_bytes {
+            return self
+                .report_tunnel_failure(
+                    &request_id,
+                    format!(
+                        "Tunnel request body exceeds advertised limit ({} > {} bytes)",
+                        body.len(),
+                        tunnel_limits.max_request_body_bytes
+                    ),
+                    write,
+                    tunnel_topic,
+                )
+                .await;
+        }
+
+        let headers_map = headers.iter().cloned().collect();
+        let _ = self
+            .event_tx
+            .send(TunnelEvent::RequestReceived {
+                request_id: request_id.clone(),
+                method: method.clone(),
+                path: path.clone(),
+                headers: headers_map,
+                body: body_preview(&body),
+                query_string: query_string.clone(),
+            })
+            .await;
+
+        self.forward_tunnel_request(
+            request_id,
+            method,
+            path,
+            query_string,
+            headers,
+            body,
+            deadline_unix_ms,
+            write,
+            tunnel_topic,
+            tunnel_limits,
+        )
+        .await
+    }
+
     #[allow(clippy::too_many_arguments)]
     async fn forward_tunnel_request(
         &self,
@@ -1340,14 +1717,10 @@ impl TunnelForwarder {
         method: String,
         path: String,
         query_string: String,
-        headers: serde_json::Map<String, serde_json::Value>,
+        headers: Vec<(String, String)>,
         body: Vec<u8>,
-        write: &mut futures_util::stream::SplitSink<
-            tokio_tungstenite::WebSocketStream<
-                tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
-            >,
-            Message,
-        >,
+        deadline_unix_ms: u64,
+        write: &mut WsWrite,
         tunnel_topic: &str,
         tunnel_limits: TunnelLimits,
     ) -> Result<()> {
@@ -1367,43 +1740,32 @@ impl TunnelForwarder {
             target.push_str(&query_string);
         }
 
-        // Create HTTP client with timeout
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(30))
-            .build()?;
+        let remaining_ms = deadline_unix_ms.saturating_sub(unix_time_ms());
+        if remaining_ms == 0 {
+            return self
+                .report_tunnel_failure(
+                    &request_id,
+                    "deadline_exceeded".to_string(),
+                    write,
+                    tunnel_topic,
+                )
+                .await;
+        }
 
-        // Build request
-        let mut req_builder = match method.as_str() {
-            "GET" => client.get(&target),
-            "POST" => client.post(&target),
-            "PUT" => client.put(&target),
-            "DELETE" => client.delete(&target),
-            "PATCH" => client.patch(&target),
-            "HEAD" => client.head(&target),
-            "OPTIONS" => client.request(reqwest::Method::OPTIONS, &target),
-            _ => {
-                warn!("Unsupported HTTP method: {}", method);
-                let _ = self
-                    .send_tunnel_error(
-                        &request_id,
-                        &format!("Unsupported method: {}", method),
-                        write,
-                        tunnel_topic,
-                    )
-                    .await;
-                return Ok(());
-            }
-        };
+        // One end-to-end deadline covers local connection and response streaming.
+        let client = tunnel_http_client(Duration::from_millis(remaining_ms))?;
+
+        let request_method = reqwest::Method::from_bytes(method.as_bytes())
+            .with_context(|| format!("Unsupported HTTP method: {method}"))?;
+        let mut req_builder = client.request(request_method, &target);
 
         // Add headers. reqwest sets request framing headers from the body we actually send.
         for (key, value) in headers {
-            if should_forward_request_header(&key) {
-                let value_str = json_value_to_string(&value);
-                if let Ok(header_name) = reqwest::header::HeaderName::from_bytes(key.as_bytes())
-                    && let Ok(header_value) = reqwest::header::HeaderValue::from_str(&value_str)
-                {
-                    req_builder = req_builder.header(header_name, header_value);
-                }
+            if should_forward_request_header(&key)
+                && let Ok(header_name) = reqwest::header::HeaderName::from_bytes(key.as_bytes())
+                && let Ok(header_value) = reqwest::header::HeaderValue::from_str(&value)
+            {
+                req_builder = req_builder.header(header_name, header_value);
             }
         }
 
@@ -1429,11 +1791,8 @@ impl TunnelForwarder {
                         .await;
                 }
 
-                let response_headers: HashMap<String, String> = response
-                    .headers()
-                    .iter()
-                    .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap_or("").to_string()))
-                    .collect();
+                let response_header_pairs = response_headers_to_pairs(response.headers());
+                let response_headers = response_headers_to_map(response.headers());
 
                 if response
                     .content_length()
@@ -1515,22 +1874,20 @@ impl TunnelForwarder {
                     })
                     .await;
 
-                // Send tunnel_response back to server with body_encoding
-                let response_message = ChannelMessage {
-                    topic: tunnel_topic.to_string(),
-                    event: "tunnel_response".to_string(),
-                    payload: serde_json::json!({
+                self.send_framed_tunnel_response(
+                    write,
+                    tunnel_topic,
+                    &request_id,
+                    deadline_unix_ms,
+                    serde_json::json!({
                         "request_id": request_id,
                         "status": status,
-                        "headers": response_headers,
+                        "headers": response_header_pairs,
                         "body": response_body,
                         "body_encoding": body_encoding,
                     }),
-                    reference: None,
-                };
-
-                let response_json = serde_json::to_string(&response_message)?;
-                write.send(Message::Text(response_json.into())).await?;
+                )
+                .await?;
             }
             Err(e) => {
                 let duration_ms = start_time.elapsed().as_millis() as u64;
@@ -1556,6 +1913,32 @@ impl TunnelForwarder {
                 self.send_tunnel_error(&request_id, &error_msg, write, tunnel_topic)
                     .await?;
             }
+        }
+
+        Ok(())
+    }
+
+    async fn send_framed_tunnel_response(
+        &self,
+        write: &mut WsWrite,
+        tunnel_topic: &str,
+        request_id: &str,
+        deadline_unix_ms: u64,
+        payload: serde_json::Value,
+    ) -> Result<()> {
+        let mut stream =
+            OutboundTunnelStream::new(request_id, "response", deadline_unix_ms, &payload)?;
+
+        send_channel_message(write, stream.start_message(tunnel_topic)).await?;
+
+        while let Some(frame) = stream.next_frame(tunnel_topic)? {
+            if unix_time_ms() >= deadline_unix_ms {
+                return Err(anyhow!("deadline_exceeded"));
+            }
+
+            // SinkExt::send waits for sink readiness, keeping the transport queue
+            // to one frame even when the service consumes slowly.
+            send_channel_message(write, frame).await?;
         }
 
         Ok(())
@@ -1720,6 +2103,7 @@ mod tests {
 
         let tunnel_payload = tunnel_join_payload(3000, Some("org-1"), Some("payments"));
         assert_eq!(tunnel_payload["mode"], DIRECT_RESPONSE_MODE);
+        assert_eq!(tunnel_payload["protocol_version"], TUNNEL_PROTOCOL_VERSION);
         assert_eq!(tunnel_payload["local_port"], 3000);
         assert_eq!(tunnel_payload["organization_id"], "org-1");
         assert_eq!(tunnel_payload["slug"], "payments");
@@ -1776,14 +2160,137 @@ mod tests {
     fn test_tunnel_websocket_config_accepts_advertised_messages() {
         let config = tunnel_websocket_config();
 
+        assert_eq!(config.max_message_size, Some(TUNNEL_MAX_FRAME_BYTES));
+        assert_eq!(config.max_frame_size, Some(TUNNEL_MAX_FRAME_BYTES));
+    }
+
+    #[test]
+    fn test_framed_stream_round_trips_with_one_bounded_frame_in_flight() {
+        let payload = serde_json::json!({
+            "request_id": "request-1",
+            "headers": [["x-repeat", "first"], ["x-repeat", "second"]],
+            "body": URL_SAFE_NO_PAD.encode(vec![0xff; 200_000]),
+            "body_encoding": "base64",
+        });
+        let deadline = unix_time_ms() + 30_000;
+        let mut outbound =
+            OutboundTunnelStream::new("request-1", "request", deadline, &payload).unwrap();
+        let start = outbound.start_message("tunnel:connect");
+        let mut inbound = TunnelStreamAssembler::from_start(&start.payload, "request").unwrap();
+        let mut decoded = None;
+        let mut peak_in_flight = 0;
+
+        while let Some(frame) = outbound.next_frame("tunnel:connect").unwrap() {
+            assert!(serde_json::to_vec(&frame).unwrap().len() <= TUNNEL_MAX_FRAME_BYTES);
+            peak_in_flight = peak_in_flight.max(1);
+            decoded = inbound.append(&frame.payload).unwrap().or(decoded);
+        }
+
+        assert_eq!(decoded.unwrap(), payload);
+        assert_eq!(peak_in_flight, 1);
+    }
+
+    #[test]
+    fn test_published_v2_contract_matches_cli_framing_constants() {
+        let fixture: serde_json::Value =
+            serde_json::from_str(include_str!("../fixtures/tunnel_framing_v2.json")).unwrap();
+
+        assert_eq!(fixture["version"], TUNNEL_PROTOCOL_VERSION);
+        assert_eq!(fixture["max_frame_bytes"], TUNNEL_MAX_FRAME_BYTES);
+        assert_eq!(fixture["max_raw_chunk_bytes"], TUNNEL_MAX_RAW_CHUNK_BYTES);
+        assert_eq!(fixture["queue_depth_frames"], 1);
+
+        let headers = ordered_header_pairs(fixture["sample_payload"].get("headers")).unwrap();
+        assert_eq!(headers[0], ("x-repeated".into(), "first".into()));
+        assert_eq!(headers[1], ("x-repeated".into(), "second".into()));
         assert_eq!(
-            config.max_message_size,
-            Some(TUNNEL_MAX_WEBSOCKET_MESSAGE_BYTES)
+            URL_SAFE_NO_PAD
+                .decode(fixture["sample_payload"]["body"].as_str().unwrap())
+                .unwrap(),
+            vec![0x00, 0xff, b'b', b'i', b'n']
         );
+    }
+
+    #[test]
+    fn test_framing_rejects_out_of_order_frames() {
+        let payload = serde_json::json!({"request_id": "request-1", "body": "ok"});
+        let deadline = unix_time_ms() + 30_000;
+        let mut outbound =
+            OutboundTunnelStream::new("request-1", "request", deadline, &payload).unwrap();
+        let start = outbound.start_message("tunnel:connect");
+        let mut inbound = TunnelStreamAssembler::from_start(&start.payload, "request").unwrap();
+        let mut frame = outbound.next_frame("tunnel:connect").unwrap().unwrap();
+        frame.payload["sequence"] = serde_json::json!(1);
+
+        assert!(
+            inbound
+                .append(&frame.payload)
+                .unwrap_err()
+                .to_string()
+                .contains("Out-of-order")
+        );
+    }
+
+    #[test]
+    fn test_ordered_headers_preserve_duplicates() {
+        let headers = ordered_header_pairs(Some(&serde_json::json!([
+            ["set-cookie", "first=1"],
+            ["set-cookie", "second=2"]
+        ])))
+        .unwrap();
+
         assert_eq!(
-            config.max_frame_size,
-            Some(TUNNEL_MAX_WEBSOCKET_MESSAGE_BYTES)
+            headers,
+            vec![
+                ("set-cookie".to_string(), "first=1".to_string()),
+                ("set-cookie".to_string(), "second=2".to_string())
+            ]
         );
+    }
+
+    #[test]
+    fn test_response_header_pairs_preserve_repeated_values() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.append("set-cookie", "first=1".parse().unwrap());
+        headers.append("set-cookie", "second=2".parse().unwrap());
+
+        assert_eq!(
+            response_headers_to_pairs(&headers),
+            vec![
+                ("set-cookie".to_string(), "first=1".to_string()),
+                ("set-cookie".to_string(), "second=2".to_string())
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_local_redirects_are_returned_without_following() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = socket.read(&mut request).await.unwrap();
+            socket
+                .write_all(
+                    b"HTTP/1.1 302 Found\r\nLocation: /must-not-follow\r\nContent-Length: 0\r\n\r\n",
+                )
+                .await
+                .unwrap();
+        });
+
+        let response = tunnel_http_client(Duration::from_secs(1))
+            .unwrap()
+            .get(format!("http://{address}/start"))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), reqwest::StatusCode::FOUND);
+        server.await.unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- separate WebSocket reading, priority writing, local forwarding, and presentation into independent ownership domains
- bound inbound streams, local work, response buffers, outbound queues, and renderer events by count and bytes
- classify deadline and cancellation outcomes at the local execution boundary and emit recoverable presentation gaps
- cover concurrent 10 MiB admission, slow/fast handlers, stalled presentation, writer priority, and interruption cleanup

## Verification

- `cargo test` (251 passed)
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`

Depends on #25.

Blocks [LEM-218](https://linear.app/lemonity/issue/LEM-218).

Closes [LEM-223](https://linear.app/lemonity/issue/LEM-223).