### PR TITLE
feat(tunnel): add cloud lifecycle commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,23 @@ reported by the service as having an unknown outcome.
 Machine-readable tunnel receipts redact authorization, cookies, API keys, tokens, and secret
 header values. Debug logs omit the access-token query parameter from WebSocket endpoints.
 
+### Operate tunnel lifecycle state
+
+Tunnel sessions, captures, delivery attempts, and events are cloud-authoritative. They remain inspectable and stoppable after the CLI process that started them exits:
+
+```bash
+hooklistener tunnel prepare --port 3000
+hooklistener tunnel start --port 3000
+hooklistener tunnel list
+hooklistener tunnel status <session-id>
+hooklistener tunnel events --cursor <cursor> --follow
+hooklistener tunnel capture <capture-id>
+hooklistener tunnel attempt <attempt-id>
+hooklistener tunnel stop <session-id> --reason "deployment complete"
+```
+
+`hooklistener tunnel --port 3000` remains an alias for `tunnel start`. Every lifecycle command negotiates the authenticated tunnel contract first; an incompatible schema major fails before relay activation.
+
 ## Work with captured requests
 
 Select an organization once for account-backed commands:
@@ -143,19 +160,22 @@ Long-running `listen --json` and `tunnel --json` commands emit newline-delimited
 ```bash
 hooklistener --json listen <endpoint-slug>
 hooklistener --json tunnel --port 3000
+hooklistener --json tunnel events --cursor <cursor> --follow
 ```
 
 Tunnel delivery is independent from terminal rendering. If a slow or stalled consumer fills the presentation queue, the CLI continues reading requests and returning local responses, then emits a recoverable `stream_gap` event with the number of presentation events omitted. Treat the displayed request history as incomplete after a gap; delivery itself is unaffected.
 
 The relay runtime admits at most 8 local requests and 64 MiB of retained request bodies at once. Inbound streams, buffered local responses, and the serialized WebSocket writer have separate count and byte ceilings. Requests rejected before the local connection begins report `known_not_executed`; cancellations or failures after forwarding begins report `outcome_unknown`.
 
+Tunnel lifecycle receipts use `hooklistener.tunnel.receipt/1`; durable events use `hooklistener.tunnel.event/1` and include an event ID, journal position, sequence, opaque resume cursor, and canonical resource links. `--json` is noninteractive and writes only NDJSON to stdout. Persist event cursors and, after a `cursor_expired` error, rehydrate from the supplied resource links before resuming at the earliest cursor. If no earliest cursor is supplied, resync the resources and request a fresh cursor.
+
 Runtime errors use a consistent envelope:
 
 ```json
-{"error":{"causes":[],"code":"command_failed","hint":null,"message":"..."},"ok":false}
+{"$schema":"hooklistener.cli.error/1","schema_version":1,"type":"error","error":{"causes":[],"code":"command_failed","hint":null,"message":"..."},"ok":false}
 ```
 
-Exit status `0` means success, `1` means a runtime failure, and `2` means command-line parsing failed. Destructive commands in scripts require `--yes`. `login` and `completions` do not support JSON output.
+Exit status `0` means success, `1` means a runtime failure, `2` means command-line parsing failed, `3` means the tunnel schema major is incompatible, and `4` means an event cursor expired. Destructive commands in scripts require `--yes`. `login` and `completions` do not support JSON output.
 
 ## Terminal behavior
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,4 +1,7 @@
-use crate::models::{ForwardResponse, WebhookRequest};
+use crate::{
+    errors::TunnelLifecycleError,
+    models::{ForwardResponse, WebhookRequest},
+};
 use anyhow::{Context, Result, anyhow};
 use reqwest::{
     Client, Response, Url,
@@ -10,6 +13,8 @@ use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 const RELAY_TICKET_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const API_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const API_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
 
 fn deserialize_map_or_default<'de, D>(
     deserializer: D,
@@ -338,6 +343,146 @@ pub struct StaticTunnelCreateResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TunnelLifecycleContract {
+    pub id: String,
+    pub version: String,
+    pub schema: TunnelSchemaVersion,
+    pub receipts: Value,
+    pub events: Value,
+    pub resources: Value,
+    pub lifecycle: Value,
+    pub exit_codes: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TunnelSchemaVersion {
+    pub major: u64,
+    pub minor: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TunnelRouteResource {
+    pub id: String,
+    pub slug: String,
+    pub kind: String,
+    pub mode: String,
+    pub status: String,
+    #[serde(default)]
+    pub expires_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TunnelSessionResource {
+    pub id: String,
+    pub organization_id: String,
+    pub status: String,
+    pub fence: u64,
+    #[serde(default)]
+    pub lease_expires_at: Option<String>,
+    #[serde(default)]
+    pub opened_at: Option<String>,
+    #[serde(default)]
+    pub closed_at: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    #[serde(default)]
+    pub route: Option<TunnelRouteResource>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TunnelCaptureResource {
+    pub id: String,
+    pub organization_id: String,
+    pub route_id: String,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub endpoint_id: Option<String>,
+    pub origin: String,
+    pub method: String,
+    pub path: String,
+    #[serde(default)]
+    pub request_content_length: Option<u64>,
+    pub request_body_captured: bool,
+    #[serde(default)]
+    pub provider_response_status: Option<u16>,
+    pub captured_at: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TunnelAttemptResource {
+    pub id: String,
+    pub organization_id: String,
+    pub capture_id: String,
+    pub session_id: String,
+    pub attempt_number: u64,
+    pub fence: u64,
+    pub status: String,
+    pub deadline_at: String,
+    #[serde(default)]
+    pub forward_started_at: Option<String>,
+    #[serde(default)]
+    pub response_observed_at: Option<String>,
+    #[serde(default)]
+    pub completed_at: Option<String>,
+    #[serde(default)]
+    pub error_code: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TunnelLifecycleEvent {
+    pub id: String,
+    pub position: u64,
+    pub cursor: String,
+    pub organization_id: String,
+    pub capture_id: String,
+    #[serde(default)]
+    pub delivery_id: Option<String>,
+    pub sequence: u64,
+    #[serde(default)]
+    pub fence: Option<u64>,
+    #[serde(rename = "type")]
+    pub event_type: String,
+    #[serde(default)]
+    pub metadata: Value,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TunnelCollection<T> {
+    pub data: Vec<T>,
+    pub meta: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TunnelEventPage {
+    pub data: Vec<TunnelLifecycleEvent>,
+    pub meta: TunnelEventPageMeta,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TunnelEventPageMeta {
+    pub cursor: String,
+    pub has_more: bool,
+    pub retention_days: u64,
+    pub resync: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TunnelReconnectDescriptor {
+    pub session: TunnelSessionResource,
+    pub topic: String,
+    pub resume_token: String,
+    pub resume_token_expires_in: u64,
+    pub cursor: String,
+    pub ownership: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MessageResponse {
     #[serde(default)]
     pub message: Option<String>,
@@ -607,6 +752,14 @@ impl ApiClient {
         access_token: String,
         organization_id: Option<String>,
     ) -> Result<Self> {
+        Self::with_base_url(access_token, default_base_url(), organization_id)
+    }
+
+    pub fn with_base_url(
+        access_token: String,
+        base_url: String,
+        organization_id: Option<String>,
+    ) -> Result<Self> {
         let mut headers = HeaderMap::new();
         let auth = format!("Bearer {}", access_token);
         headers.insert(
@@ -623,24 +776,15 @@ impl ApiClient {
 
         let client = Client::builder()
             .default_headers(headers)
+            .connect_timeout(API_CONNECT_TIMEOUT)
+            .timeout(API_REQUEST_TIMEOUT)
             .build()
             .context("Failed to build API client")?;
 
         Ok(Self {
             client,
-            base_url: Some(default_base_url()),
+            base_url: Some(base_url),
         })
-    }
-
-    #[cfg(test)]
-    pub fn with_base_url(
-        access_token: String,
-        base_url: String,
-        organization_id: Option<String>,
-    ) -> Result<Self> {
-        let mut client = Self::with_organization(access_token, organization_id)?;
-        client.base_url = Some(base_url);
-        Ok(client)
     }
 
     fn api_url(&self, path: &str) -> Result<String> {
@@ -667,6 +811,88 @@ impl ApiClient {
         }
 
         serde_json::from_str(&text).with_context(|| format!("Failed to parse {} response", context))
+    }
+
+    async fn parse_tunnel_response<T: DeserializeOwned>(
+        &self,
+        response: Response,
+        context: &str,
+    ) -> Result<T> {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        if status.is_success() {
+            return serde_json::from_str(&text)
+                .with_context(|| format!("Failed to parse {context} response"));
+        }
+
+        let body: Value = serde_json::from_str(&text).unwrap_or(Value::Null);
+        let error = body.get("error").unwrap_or(&Value::Null);
+        let code = error
+            .get("code")
+            .and_then(Value::as_str)
+            .unwrap_or("tunnel_api_error");
+        let message = error
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or(context);
+
+        if code == "cursor_expired" {
+            return Err(TunnelLifecycleError::CursorExpired {
+                earliest_cursor: error
+                    .get("earliest_cursor")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+                resync: error.get("resync").cloned().unwrap_or(Value::Null),
+            }
+            .into());
+        }
+
+        Err(TunnelLifecycleError::Api {
+            status: status.as_u16(),
+            code: code.to_string(),
+            message: message.to_string(),
+        }
+        .into())
+    }
+
+    async fn get_tunnel_json<T: DeserializeOwned>(
+        &self,
+        path: &str,
+        query: &[(&str, Option<String>)],
+        context: &str,
+    ) -> Result<T> {
+        let mut url = Url::parse(&self.api_url(path)?)?;
+        if query.iter().any(|(_, value)| value.is_some()) {
+            let mut pairs = url.query_pairs_mut();
+            for (key, value) in query {
+                if let Some(value) = value {
+                    pairs.append_pair(key, value);
+                }
+            }
+        }
+        let response = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .with_context(|| format!("Failed to {context}"))?;
+        self.parse_tunnel_response(response, context).await
+    }
+
+    async fn post_tunnel_json<T: DeserializeOwned>(
+        &self,
+        path: &str,
+        body: &Value,
+        context: &str,
+    ) -> Result<T> {
+        let response = self
+            .client
+            .post(self.api_url(path)?)
+            .json(body)
+            .send()
+            .await
+            .with_context(|| format!("Failed to {context}"))?;
+        self.parse_tunnel_response(response, context).await
     }
 
     async fn get_json<T: DeserializeOwned>(&self, path: &str, context: &str) -> Result<T> {
@@ -911,6 +1137,108 @@ impl ApiClient {
             organization_id, slug_id
         );
         self.delete_json(&path, "delete static tunnel").await
+    }
+
+    pub async fn tunnel_lifecycle_contract(&self) -> Result<TunnelLifecycleContract> {
+        let response: DataResponse<TunnelLifecycleContract> = self
+            .get_tunnel_json("/api/v1/tunnel/contract", &[], "read tunnel contract")
+            .await?;
+        Ok(response.data)
+    }
+
+    pub async fn list_tunnel_sessions(
+        &self,
+        limit: u16,
+        status: Option<&str>,
+    ) -> Result<TunnelCollection<TunnelSessionResource>> {
+        self.get_tunnel_json(
+            "/api/v1/tunnel/sessions",
+            &[
+                ("limit", Some(limit.to_string())),
+                ("status", status.map(str::to_string)),
+            ],
+            "list tunnel sessions",
+        )
+        .await
+    }
+
+    pub async fn get_tunnel_session(&self, id: &str) -> Result<TunnelSessionResource> {
+        let response: DataResponse<TunnelSessionResource> = self
+            .get_tunnel_json(
+                &format!("/api/v1/tunnel/sessions/{id}"),
+                &[],
+                "read tunnel session",
+            )
+            .await?;
+        Ok(response.data)
+    }
+
+    pub async fn stop_tunnel_session(
+        &self,
+        id: &str,
+        reason: Option<&str>,
+    ) -> Result<TunnelSessionResource> {
+        let response: DataResponse<TunnelSessionResource> = self
+            .post_tunnel_json(
+                &format!("/api/v1/tunnel/sessions/{id}/close"),
+                &serde_json::json!({"reason": reason}),
+                "stop tunnel session",
+            )
+            .await?;
+        Ok(response.data)
+    }
+
+    pub async fn reconnect_tunnel_session(&self, id: &str) -> Result<TunnelReconnectDescriptor> {
+        let response: DataResponse<TunnelReconnectDescriptor> = self
+            .post_tunnel_json(
+                &format!("/api/v1/tunnel/sessions/{id}/reconnect"),
+                &serde_json::json!({}),
+                "prepare tunnel session reconnect",
+            )
+            .await?;
+        Ok(response.data)
+    }
+
+    pub async fn list_tunnel_events(
+        &self,
+        cursor: Option<&str>,
+        limit: u16,
+        capture_id: Option<&str>,
+        attempt_id: Option<&str>,
+    ) -> Result<TunnelEventPage> {
+        self.get_tunnel_json(
+            "/api/v1/tunnel/events",
+            &[
+                ("cursor", cursor.map(str::to_string)),
+                ("limit", Some(limit.to_string())),
+                ("capture_id", capture_id.map(str::to_string)),
+                ("delivery_id", attempt_id.map(str::to_string)),
+            ],
+            "read tunnel events",
+        )
+        .await
+    }
+
+    pub async fn get_tunnel_capture(&self, id: &str) -> Result<TunnelCaptureResource> {
+        let response: DataResponse<TunnelCaptureResource> = self
+            .get_tunnel_json(
+                &format!("/api/v1/tunnel/captures/{id}"),
+                &[],
+                "read tunnel capture",
+            )
+            .await?;
+        Ok(response.data)
+    }
+
+    pub async fn get_tunnel_attempt(&self, id: &str) -> Result<TunnelAttemptResource> {
+        let response: DataResponse<TunnelAttemptResource> = self
+            .get_tunnel_json(
+                &format!("/api/v1/tunnel/deliveries/{id}"),
+                &[],
+                "read tunnel delivery attempt",
+            )
+            .await?;
+        Ok(response.data)
     }
 
     // ── Uptime Monitor methods ──────────────────────────────────────────────
@@ -1382,5 +1710,131 @@ mod tests {
         );
         assert_eq!(result.passed_count, 1);
         mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_tunnel_contract_and_resources_use_authenticated_cloud_state() {
+        let mut server = mockito::Server::new_async().await;
+        let contract_mock = server
+            .mock("GET", "/api/v1/tunnel/contract")
+            .match_header("authorization", "Bearer test-token")
+            .match_header("x-organization-id", "org-123")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"id":"hooklistener.tunnel.lifecycle","version":"1.0.0","schema":{"major":1,"minor":0},"receipts":{},"events":{},"resources":{},"lifecycle":{},"exit_codes":{}}}"#,
+            )
+            .create_async()
+            .await;
+        let session_mock = server
+            .mock("GET", "/api/v1/tunnel/sessions/session-123")
+            .match_header("authorization", "Bearer test-token")
+            .match_header("x-organization-id", "org-123")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"id":"session-123","organization_id":"org-123","status":"active","fence":1,"created_at":"2026-07-14T20:00:00Z","updated_at":"2026-07-14T20:00:01Z","route":null}}"#,
+            )
+            .create_async()
+            .await;
+        let reconnect_mock = server
+            .mock("POST", "/api/v1/tunnel/sessions/session-123/reconnect")
+            .match_header("authorization", "Bearer test-token")
+            .match_header("x-organization-id", "org-123")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"session":{"id":"session-123","organization_id":"org-123","status":"active","fence":1,"created_at":"2026-07-14T20:00:00Z","updated_at":"2026-07-14T20:00:01Z","route":null},"topic":"tunnel:connect","resume_token":"secret-resume-token","resume_token_expires_in":300,"cursor":"opaque","ownership":"lost"}}"#,
+            )
+            .create_async()
+            .await;
+        let client = ApiClient::with_base_url(
+            "test-token".to_string(),
+            server.url(),
+            Some("org-123".to_string()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            client.tunnel_lifecycle_contract().await.unwrap().version,
+            "1.0.0"
+        );
+        assert_eq!(
+            client
+                .get_tunnel_session("session-123")
+                .await
+                .unwrap()
+                .status,
+            "active"
+        );
+        let reconnect = client
+            .reconnect_tunnel_session("session-123")
+            .await
+            .unwrap();
+        assert_eq!(reconnect.cursor, "opaque");
+        assert_eq!(reconnect.resume_token, "secret-resume-token");
+        contract_mock.assert_async().await;
+        session_mock.assert_async().await;
+        reconnect_mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_tunnel_cursor_expiry_is_a_typed_error() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/api/v1/tunnel/events")
+            .match_query(mockito::Matcher::Any)
+            .with_status(409)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"error":{"code":"cursor_expired","message":"expired","earliest_cursor":"earliest","resync":{"sessions":"/api/v1/tunnel/sessions"}}}"#,
+            )
+            .create_async()
+            .await;
+        let client =
+            ApiClient::with_base_url("test-token".to_string(), server.url(), None).unwrap();
+
+        let error = client
+            .list_tunnel_events(Some("expired"), 50, None, None)
+            .await
+            .unwrap_err();
+        let lifecycle = error.downcast_ref::<TunnelLifecycleError>().unwrap();
+        assert!(matches!(
+            lifecycle,
+            TunnelLifecycleError::CursorExpired {
+                earliest_cursor: Some(cursor),
+                ..
+            } if cursor == "earliest"
+        ));
+        mock.assert_async().await;
+    }
+
+    #[test]
+    fn test_tunnel_capture_projection_drops_unrecognized_sensitive_fields() {
+        let capture: TunnelCaptureResource = serde_json::from_value(serde_json::json!({
+            "id": "capture-123",
+            "organization_id": "org-123",
+            "route_id": "route-123",
+            "session_id": "session-123",
+            "endpoint_id": null,
+            "origin": "tunnel",
+            "method": "POST",
+            "path": "/billing",
+            "request_content_length": 6,
+            "request_body_captured": true,
+            "provider_response_status": 200,
+            "captured_at": "2026-07-14T20:00:00Z",
+            "created_at": "2026-07-14T20:00:00Z",
+            "updated_at": "2026-07-14T20:00:01Z",
+            "request_headers": {"authorization": "Bearer secret"},
+            "request_body": "secret",
+            "object_storage_key": "private/key"
+        }))
+        .unwrap();
+
+        let output = serde_json::to_string(&capture).unwrap();
+        assert!(!output.contains("authorization"));
+        assert!(!output.contains("Bearer secret"));
+        assert!(!output.contains("private/key"));
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -109,6 +109,56 @@ impl TunnelError {
     }
 }
 
+#[derive(Debug, Error)]
+pub enum TunnelLifecycleError {
+    #[error("Tunnel lifecycle schema {actual} is incompatible with supported major {supported}")]
+    IncompatibleSchema { supported: u64, actual: u64 },
+
+    #[error("Tunnel event cursor expired")]
+    CursorExpired {
+        earliest_cursor: Option<String>,
+        resync: serde_json::Value,
+    },
+
+    #[error("Tunnel API request failed ({code}, HTTP {status}): {message}")]
+    Api {
+        status: u16,
+        code: String,
+        message: String,
+    },
+}
+
+impl TunnelLifecycleError {
+    pub fn code(&self) -> &str {
+        match self {
+            Self::IncompatibleSchema { .. } => "incompatible_schema",
+            Self::CursorExpired { .. } => "cursor_expired",
+            Self::Api { code, .. } => code,
+        }
+    }
+
+    pub fn hint(&self) -> Option<&str> {
+        match self {
+            Self::IncompatibleSchema { .. } => {
+                Some("Upgrade Hooklistener CLI before activating this tunnel.")
+            }
+            Self::CursorExpired {
+                earliest_cursor: Some(_),
+                ..
+            } => Some(
+                "Rehydrate sessions, captures, attempts, and outcomes, then resume from the earliest cursor.",
+            ),
+            Self::CursorExpired {
+                earliest_cursor: None,
+                ..
+            } => Some(
+                "Resync sessions, captures, attempts, and outcomes, then request a fresh event cursor.",
+            ),
+            Self::Api { .. } => None,
+        }
+    }
+}
+
 #[allow(dead_code)]
 #[derive(Debug, Error)]
 pub enum ConfigError {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ mod updater;
 
 use anyhow::{Result, anyhow};
 use chrono::{Duration as ChronoDuration, Utc};
-use clap::{ArgAction, CommandFactory, Parser, Subcommand, ValueEnum};
+use clap::{ArgAction, Args, CommandFactory, Parser, Subcommand, ValueEnum};
 use comfy_table::{ContentArrangement, Table, presets::UTF8_FULL_CONDENSED};
 use crossterm::{
     cursor::{MoveToColumn, Show},
@@ -173,29 +173,134 @@ enum Commands {
     Update,
     /// Expose a local HTTP server on a public Hooklistener URL
     Tunnel {
-        /// Local port to forward requests to
-        #[arg(short, long, default_value = "3000")]
-        port: u16,
+        #[command(subcommand)]
+        action: Option<TunnelAction>,
 
-        /// Local host to forward to
-        #[arg(long, default_value = "localhost")]
-        host: String,
+        #[command(flatten)]
+        target: TunnelTargetArgs,
+    },
+}
 
-        /// Organization ID (optional, uses default)
-        #[arg(short, long)]
+#[derive(Args, Clone, Default)]
+struct TunnelTargetArgs {
+    /// Local port to forward requests to (default: 3000)
+    #[arg(short, long)]
+    port: Option<u16>,
+
+    /// Local host to forward to (default: localhost)
+    #[arg(long)]
+    host: Option<String>,
+
+    /// Organization ID override (falls back to configured default)
+    #[arg(short, long)]
+    org: Option<String>,
+
+    /// Static tunnel slug (paid plans only, creates persistent subdomain)
+    #[arg(short, long)]
+    slug: Option<String>,
+
+    /// Allow forwarding to a host that resolves outside loopback
+    #[arg(long)]
+    allow_non_loopback: bool,
+
+    /// Do not automatically replay requests buffered while the tunnel was offline
+    #[arg(long)]
+    no_replay_buffered: bool,
+}
+
+impl TunnelTargetArgs {
+    fn merge(self, action_target: Self) -> Self {
+        Self {
+            port: action_target.port.or(self.port),
+            host: action_target.host.or(self.host),
+            org: action_target.org.or(self.org),
+            slug: action_target.slug.or(self.slug),
+            allow_non_loopback: self.allow_non_loopback || action_target.allow_non_loopback,
+            no_replay_buffered: self.no_replay_buffered || action_target.no_replay_buffered,
+        }
+    }
+
+    fn resolve(self) -> TunnelTarget {
+        TunnelTarget {
+            port: self.port.unwrap_or(3000),
+            host: self.host.unwrap_or_else(|| "localhost".to_string()),
+            org: self.org,
+            slug: self.slug,
+            allow_non_loopback: self.allow_non_loopback,
+            no_replay_buffered: self.no_replay_buffered,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct TunnelTarget {
+    port: u16,
+    host: String,
+    org: Option<String>,
+    slug: Option<String>,
+    allow_non_loopback: bool,
+    no_replay_buffered: bool,
+}
+
+#[derive(Subcommand)]
+enum TunnelAction {
+    /// Validate authentication, schema compatibility, and the activation plan
+    Prepare(TunnelTargetArgs),
+    /// Activate a relay and keep it attached to the local target
+    Activate(TunnelTargetArgs),
+    /// Prepare and activate a relay (the default tunnel behavior)
+    Start(TunnelTargetArgs),
+    /// List cloud-authoritative tunnel sessions
+    List {
+        #[arg(long, default_value = "50", value_parser = clap::value_parser!(u16).range(1..=100))]
+        limit: u16,
+        #[arg(long)]
+        status: Option<String>,
+        #[arg(long)]
         org: Option<String>,
-
-        /// Static tunnel slug (paid plans only, creates persistent subdomain)
-        #[arg(short, long)]
-        slug: Option<String>,
-
-        /// Allow forwarding to a host that resolves outside loopback
+    },
+    /// Read a tunnel session by canonical ID
+    Status {
+        session_id: String,
         #[arg(long)]
-        allow_non_loopback: bool,
-
-        /// Do not automatically replay requests buffered while the tunnel was offline
+        org: Option<String>,
+    },
+    /// Read ordered lifecycle events, optionally following from a cursor
+    Events {
         #[arg(long)]
-        no_replay_buffered: bool,
+        cursor: Option<String>,
+        #[arg(long, default_value = "50", value_parser = clap::value_parser!(u16).range(1..=100))]
+        limit: u16,
+        #[arg(long)]
+        capture_id: Option<String>,
+        #[arg(long)]
+        attempt_id: Option<String>,
+        #[arg(long)]
+        follow: bool,
+        #[arg(long, default_value = "1000")]
+        interval_ms: u64,
+        #[arg(long)]
+        org: Option<String>,
+    },
+    /// Read a redacted capture projection by canonical ID
+    Capture {
+        capture_id: String,
+        #[arg(long)]
+        org: Option<String>,
+    },
+    /// Read a delivery attempt by canonical ID
+    Attempt {
+        attempt_id: String,
+        #[arg(long)]
+        org: Option<String>,
+    },
+    /// Stop a tunnel session even when its original CLI process is gone
+    Stop {
+        session_id: String,
+        #[arg(long)]
+        reason: Option<String>,
+        #[arg(long)]
+        org: Option<String>,
     },
 }
 
@@ -855,13 +960,18 @@ fn effective_listen_ws_url(ws_url: Option<&str>) -> String {
 }
 
 fn command_event_receipt(
+    schema: &str,
     command: &str,
     operation: &str,
     event: &str,
     status: &str,
 ) -> serde_json::Value {
     serde_json::json!({
+        "$schema": schema,
+        "schema_version": 1,
         "type": "event",
+        "event_id": uuid::Uuid::new_v4(),
+        "sequence": 0,
         "event": event,
         "status": status,
         "command": command,
@@ -876,7 +986,13 @@ fn listen_event_base(
     endpoint_slug: &str,
     target_url: &str,
 ) -> serde_json::Value {
-    let mut receipt = command_event_receipt("listen", "listen_endpoint", event, status);
+    let mut receipt = command_event_receipt(
+        LISTEN_EVENT_SCHEMA,
+        "listen",
+        "listen_endpoint",
+        event,
+        status,
+    );
     receipt["endpoint_slug"] = serde_json::json!(endpoint_slug);
     receipt["target_url"] = serde_json::json!(target_url);
     receipt["resource_uri"] = serde_json::json!(listen_session_resource_uri(endpoint_slug));
@@ -884,7 +1000,13 @@ fn listen_event_base(
 }
 
 fn tunnel_event_base(event: &str, status: &str) -> serde_json::Value {
-    command_event_receipt("tunnel", "start_local_tunnel", event, status)
+    command_event_receipt(
+        TUNNEL_EVENT_SCHEMA,
+        "tunnel",
+        "start_local_tunnel",
+        event,
+        status,
+    )
 }
 
 fn redact_tunnel_headers(
@@ -1160,7 +1282,11 @@ fn tunnel_started_receipt(
     let local_target_url = local_tunnel_target_url(host, port);
 
     serde_json::json!({
+        "$schema": TUNNEL_RECEIPT_SCHEMA,
+        "schema_version": 1,
         "type": "receipt",
+        "event_id": uuid::Uuid::new_v4(),
+        "sequence": 0,
         "event": "tunnel_started",
         "status": "starting",
         "command": "tunnel",
@@ -1608,6 +1734,7 @@ async fn stream_listen_json_events(
     target_url: &str,
     endpoint: Option<&api::DebugEndpointSummary>,
 ) -> Result<()> {
+    let mut sequence = 1_u64;
     loop {
         tokio::select! {
             maybe_event = event_rx.recv() => {
@@ -1616,7 +1743,11 @@ async fn stream_listen_json_events(
                 };
                 let failure_reason = reconnect_failure_reason(&event);
 
-                print_json_line(&listen_event_receipt(&event, endpoint_slug, target_url, endpoint))?;
+                let mut receipt =
+                    listen_event_receipt(&event, endpoint_slug, target_url, endpoint);
+                receipt["sequence"] = serde_json::json!(sequence);
+                sequence = sequence.saturating_add(1);
+                print_json_line(&receipt)?;
 
                 if let Some(reason) = failure_reason {
                     return Err(anyhow!("Connection lost: {reason}"));
@@ -1624,17 +1755,19 @@ async fn stream_listen_json_events(
             }
             signal = tokio::signal::ctrl_c() => {
                 signal?;
-                print_json_line(&serde_json::json!({
-                    "type": "event",
-                    "event": "stopped",
-                    "status": "stopped",
-                    "command": "listen",
-                    "operation": "listen_endpoint",
-                    "emitted_at": emitted_at(),
-                    "endpoint_slug": endpoint_slug,
-                    "target_url": target_url,
-                    "resource_uri": listen_session_resource_uri(endpoint_slug)
-                }))?;
+                let mut receipt = command_event_receipt(
+                    LISTEN_EVENT_SCHEMA,
+                    "listen",
+                    "listen_endpoint",
+                    "stopped",
+                    "stopped",
+                );
+                receipt["sequence"] = serde_json::json!(sequence);
+                receipt["endpoint_slug"] = serde_json::json!(endpoint_slug);
+                receipt["target_url"] = serde_json::json!(target_url);
+                receipt["resource_uri"] =
+                    serde_json::json!(listen_session_resource_uri(endpoint_slug));
+                print_json_line(&receipt)?;
                 return Ok(());
             }
         }
@@ -1691,6 +1824,7 @@ async fn stream_tunnel_json_events(
     organization_id: Option<&str>,
     requested_slug: Option<&str>,
 ) -> Result<()> {
+    let mut sequence = 1_u64;
     loop {
         tokio::select! {
             maybe_event = event_rx.recv() => {
@@ -1699,13 +1833,16 @@ async fn stream_tunnel_json_events(
                 };
                 let failure_reason = reconnect_failure_reason(&event);
 
-                print_json_line(&tunnel_event_receipt(
+                let mut receipt = tunnel_event_receipt(
                     &event,
                     host,
                     port,
                     organization_id,
                     requested_slug,
-                ))?;
+                );
+                receipt["sequence"] = serde_json::json!(sequence);
+                sequence = sequence.saturating_add(1);
+                print_json_line(&receipt)?;
 
                 if let Some(reason) = failure_reason {
                     return Err(anyhow!("Connection lost: {reason}"));
@@ -1713,16 +1850,19 @@ async fn stream_tunnel_json_events(
             }
             signal = tokio::signal::ctrl_c() => {
                 signal?;
-                print_json_line(&serde_json::json!({
-                    "type": "event",
-                    "event": "stopped",
-                    "status": "stopped",
-                    "command": "tunnel",
-                    "operation": "start_local_tunnel",
-                    "emitted_at": emitted_at(),
-                    "resource_uri": tunnel_session_resource_uri(host, port),
-                    "local_target_url": local_tunnel_target_url(host, port)
-                }))?;
+                let mut receipt = command_event_receipt(
+                    TUNNEL_EVENT_SCHEMA,
+                    "tunnel",
+                    "start_local_tunnel",
+                    "stopped",
+                    "stopped",
+                );
+                receipt["sequence"] = serde_json::json!(sequence);
+                receipt["resource_uri"] =
+                    serde_json::json!(tunnel_session_resource_uri(host, port));
+                receipt["local_target_url"] =
+                    serde_json::json!(local_tunnel_target_url(host, port));
+                print_json_line(&receipt)?;
                 return Ok(());
             }
         }
@@ -1777,7 +1917,7 @@ async fn main() {
 
     if let Err(err) = run(cli).await {
         display_error(&err, json);
-        std::process::exit(1);
+        std::process::exit(command_exit_code(&err));
     }
 }
 
@@ -2926,14 +3066,7 @@ async fn run(cli: Cli) -> Result<()> {
         Commands::Update => {
             updater::run_self_update(json).await?;
         }
-        Commands::Tunnel {
-            port,
-            host,
-            org,
-            slug,
-            allow_non_loopback,
-            no_replay_buffered,
-        } => {
+        Commands::Tunnel { action, target } => {
             // Initialize logging for tunnel
             let log_config = LogConfig {
                 level: log_level.clone(),
@@ -2944,77 +3077,7 @@ async fn run(cli: Cli) -> Result<()> {
                 ..Default::default()
             };
             let _logger = Logger::new(log_config)?;
-
-            let mut config = config::Config::load()?;
-            let selected_org = resolve_tunnel_org(org, &config);
-            let access_token = ensure_valid_token(&mut config).await?;
-            let access_token_rx = refreshed_access_token_rx(access_token, config);
-            let target = target_policy::TargetPolicy::resolve(
-                &local_tunnel_target_url(&host, port),
-                allow_non_loopback,
-                false,
-            )
-            .await?;
-
-            let replay_buffered = !no_replay_buffered;
-
-            if json {
-                run_tunnel_json(
-                    access_token_rx,
-                    host,
-                    port,
-                    selected_org,
-                    slug,
-                    target,
-                    replay_buffered,
-                )
-                .await?;
-            } else {
-                // Setup TUI for tunnel command
-                let mut terminal = setup_terminal()?;
-                let mut app = App::new()?;
-                app.monochrome = !output::styles_enabled();
-
-                // Set app state to tunneling
-                app.state = AppState::Tunneling;
-                app.tunnel_local_host = host.clone();
-                app.tunnel_local_port = port;
-                // Prefer explicit CLI org, then fall back to configured organization.
-                app.tunnel_org_id = selected_org.clone();
-                app.tunnel_requested_slug = slug.clone();
-
-                // Create channel for tunnel events
-                let (event_tx, event_rx) = mpsc::channel(tunnel::PRESENTATION_QUEUE_CAPACITY);
-
-                // Create and spawn tunnel forwarder manager
-                let reconnect_tx = spawn_tunnel_forwarder_manager(
-                    access_token_rx,
-                    host,
-                    port,
-                    selected_org,
-                    slug,
-                    target,
-                    event_tx.clone(),
-                    replay_buffered,
-                );
-
-                let res = run_app(
-                    &mut terminal,
-                    &mut app,
-                    event_rx,
-                    Some(reconnect_tx),
-                    Some(event_tx),
-                    Some(logo::spawn_logo_animation()),
-                )
-                .await;
-
-                restore_terminal(&mut terminal)?;
-
-                if let Err(err) = res {
-                    error!(error = %err, "Application terminated with error");
-                    return Err(err);
-                }
-            }
+            run_tunnel_lifecycle_command(action, target, json).await?;
         }
     }
 
@@ -3028,6 +3091,494 @@ async fn run(cli: Cli) -> Result<()> {
     }
 
     Ok(())
+}
+
+const SUPPORTED_TUNNEL_SCHEMA_MAJOR: u64 = 1;
+const TUNNEL_RECEIPT_SCHEMA: &str = "hooklistener.tunnel.receipt/1";
+const TUNNEL_EVENT_SCHEMA: &str = "hooklistener.tunnel.event/1";
+const LISTEN_EVENT_SCHEMA: &str = "hooklistener.listen.event/1";
+const COMMAND_ERROR_SCHEMA: &str = "hooklistener.cli.error/1";
+
+struct TunnelLifecycleContext {
+    config: config::Config,
+    access_token: String,
+    organization_id: String,
+    client: ApiClient,
+    contract: api::TunnelLifecycleContract,
+}
+
+struct TunnelEventOptions {
+    cursor: Option<String>,
+    limit: u16,
+    capture_id: Option<String>,
+    attempt_id: Option<String>,
+    follow: bool,
+    interval_ms: u64,
+}
+
+async fn tunnel_lifecycle_context(org: Option<String>) -> Result<TunnelLifecycleContext> {
+    let mut config = config::Config::load()?;
+    let organization_id = require_organization(org, &config)?;
+    let access_token = ensure_valid_token(&mut config).await?;
+    let client = ApiClient::with_organization(access_token.clone(), Some(organization_id.clone()))?;
+    let contract = client.tunnel_lifecycle_contract().await?;
+    validate_tunnel_schema(&contract)?;
+
+    Ok(TunnelLifecycleContext {
+        config,
+        access_token,
+        organization_id,
+        client,
+        contract,
+    })
+}
+
+fn validate_tunnel_schema(contract: &api::TunnelLifecycleContract) -> Result<()> {
+    if contract.schema.major == SUPPORTED_TUNNEL_SCHEMA_MAJOR {
+        return Ok(());
+    }
+
+    Err(errors::TunnelLifecycleError::IncompatibleSchema {
+        supported: SUPPORTED_TUNNEL_SCHEMA_MAJOR,
+        actual: contract.schema.major,
+    }
+    .into())
+}
+
+fn tunnel_lifecycle_receipt(
+    operation: &str,
+    status: &str,
+    organization_id: &str,
+    resource_uri: Option<&str>,
+    data: serde_json::Value,
+) -> serde_json::Value {
+    serde_json::json!({
+        "$schema": TUNNEL_RECEIPT_SCHEMA,
+        "schema_version": 1,
+        "type": "receipt",
+        "event_id": uuid::Uuid::new_v4(),
+        "sequence": 0,
+        "command": "tunnel",
+        "operation": operation,
+        "status": status,
+        "emitted_at": emitted_at(),
+        "organization_id": organization_id,
+        "resource_uri": resource_uri,
+        "data": data,
+    })
+}
+
+fn tunnel_lifecycle_event_envelope(event: &api::TunnelLifecycleEvent) -> serde_json::Value {
+    serde_json::json!({
+        "$schema": TUNNEL_EVENT_SCHEMA,
+        "schema_version": 1,
+        "type": "event",
+        "event": event.event_type,
+        "event_id": event.id,
+        "position": event.position,
+        "sequence": event.sequence,
+        "cursor": event.cursor,
+        "emitted_at": event.created_at,
+        "organization_id": event.organization_id,
+        "capture_id": event.capture_id,
+        "attempt_id": event.delivery_id,
+        "fence": event.fence,
+        "metadata": safe_tunnel_event_metadata(&event.metadata),
+        "resources": {
+            "capture": format!("hooklistener://tunnel/captures/{}", event.capture_id),
+            "attempt": event.delivery_id.as_ref().map(|id| format!("hooklistener://tunnel/attempts/{id}")),
+            "event": format!("hooklistener://tunnel/events/{}", event.id),
+        }
+    })
+}
+
+fn safe_tunnel_event_metadata(metadata: &serde_json::Value) -> serde_json::Value {
+    let Some(metadata) = metadata.as_object() else {
+        return serde_json::json!({});
+    };
+    let mut safe = serde_json::Map::new();
+
+    for key in [
+        "source",
+        "source_delivery_id",
+        "session_id",
+        "route_id",
+        "delivery_id",
+        "error_code",
+    ] {
+        if let Some(value) = metadata.get(key).filter(|value| value.is_string()) {
+            safe.insert(key.to_string(), value.clone());
+        }
+    }
+    for key in ["status_code", "duration_ms"] {
+        if let Some(value) = metadata.get(key).filter(|value| value.is_number()) {
+            safe.insert(key.to_string(), value.clone());
+        }
+    }
+
+    serde_json::Value::Object(safe)
+}
+
+async fn run_tunnel_lifecycle_command(
+    action: Option<TunnelAction>,
+    default_target: TunnelTargetArgs,
+    json: bool,
+) -> Result<()> {
+    match action {
+        None => run_tunnel_activation(default_target.resolve(), json).await,
+        Some(TunnelAction::Start(target)) | Some(TunnelAction::Activate(target)) => {
+            run_tunnel_activation(default_target.merge(target).resolve(), json).await
+        }
+        Some(TunnelAction::Prepare(target)) => {
+            let target = default_target.merge(target).resolve();
+            validate_tunnel_target(&target)?;
+            let local_target_url = local_tunnel_target_url(&target.host, target.port);
+            let target_policy = target_policy::TargetPolicy::resolve(
+                &local_target_url,
+                target.allow_non_loopback,
+                false,
+            )
+            .await?;
+            let replay_buffered = !target.no_replay_buffered;
+            let context = tunnel_lifecycle_context(target.org.clone()).await?;
+            let receipt = tunnel_lifecycle_receipt(
+                "prepare",
+                "prepared",
+                &context.organization_id,
+                None,
+                serde_json::json!({
+                    "contract": {
+                        "id": context.contract.id,
+                        "version": context.contract.version,
+                        "schema": context.contract.schema,
+                    },
+                    "activation": {
+                        "local_target_url": local_target_url,
+                        "requested_slug": target.slug,
+                        "target": target_policy.plan(),
+                        "replay_buffered": replay_buffered,
+                    }
+                }),
+            );
+            if json {
+                print_json_line(&receipt)
+            } else {
+                print_status(OutputStatus::Ok, "TUNNEL PREPARED");
+                println!();
+                print_field("TARGET", local_target_url);
+                print_field("ORGANIZATION", context.organization_id);
+                print_field("CONTRACT", context.contract.version);
+                if let Some(slug) = target.slug {
+                    print_field("SLUG", slug);
+                }
+                Ok(())
+            }
+        }
+        Some(TunnelAction::List { limit, status, org }) => {
+            let context = tunnel_lifecycle_context(org).await?;
+            let sessions = context
+                .client
+                .list_tunnel_sessions(limit, status.as_deref())
+                .await?;
+            let receipt = tunnel_lifecycle_receipt(
+                "list",
+                "succeeded",
+                &context.organization_id,
+                Some("hooklistener://tunnel/sessions"),
+                serde_json::to_value(&sessions)?,
+            );
+            if json {
+                print_json_line(&receipt)
+            } else {
+                print_tunnel_sessions(&sessions.data, &context.organization_id);
+                Ok(())
+            }
+        }
+        Some(TunnelAction::Status { session_id, org }) => {
+            let context = tunnel_lifecycle_context(org).await?;
+            let session = context.client.get_tunnel_session(&session_id).await?;
+            print_tunnel_lifecycle_resource(
+                json,
+                "status",
+                "hooklistener://tunnel/sessions",
+                &session.id,
+                &context.organization_id,
+                &session,
+            )
+        }
+        Some(TunnelAction::Capture { capture_id, org }) => {
+            let context = tunnel_lifecycle_context(org).await?;
+            let capture = context.client.get_tunnel_capture(&capture_id).await?;
+            print_tunnel_lifecycle_resource(
+                json,
+                "capture",
+                "hooklistener://tunnel/captures",
+                &capture.id,
+                &context.organization_id,
+                &capture,
+            )
+        }
+        Some(TunnelAction::Attempt { attempt_id, org }) => {
+            let context = tunnel_lifecycle_context(org).await?;
+            let attempt = context.client.get_tunnel_attempt(&attempt_id).await?;
+            print_tunnel_lifecycle_resource(
+                json,
+                "attempt",
+                "hooklistener://tunnel/attempts",
+                &attempt.id,
+                &context.organization_id,
+                &attempt,
+            )
+        }
+        Some(TunnelAction::Stop {
+            session_id,
+            reason,
+            org,
+        }) => {
+            let context = tunnel_lifecycle_context(org).await?;
+            let session = context
+                .client
+                .stop_tunnel_session(&session_id, reason.as_deref())
+                .await?;
+            print_tunnel_lifecycle_resource(
+                json,
+                "stop",
+                "hooklistener://tunnel/sessions",
+                &session.id,
+                &context.organization_id,
+                &session,
+            )
+        }
+        Some(TunnelAction::Events {
+            cursor,
+            limit,
+            capture_id,
+            attempt_id,
+            follow,
+            interval_ms,
+            org,
+        }) => {
+            let context = tunnel_lifecycle_context(org).await?;
+            run_tunnel_lifecycle_events(
+                &context,
+                TunnelEventOptions {
+                    cursor,
+                    limit,
+                    capture_id,
+                    attempt_id,
+                    follow,
+                    interval_ms,
+                },
+                json,
+            )
+            .await
+        }
+    }
+}
+
+async fn run_tunnel_activation(target: TunnelTarget, json: bool) -> Result<()> {
+    validate_tunnel_target(&target)?;
+    let local_target_url = local_tunnel_target_url(&target.host, target.port);
+    let target_policy =
+        target_policy::TargetPolicy::resolve(&local_target_url, target.allow_non_loopback, false)
+            .await?;
+    let replay_buffered = !target.no_replay_buffered;
+    let context = tunnel_lifecycle_context(target.org.clone()).await?;
+    let access_token_rx = refreshed_access_token_rx(context.access_token, context.config);
+    let selected_org = Some(context.organization_id);
+
+    if json {
+        run_tunnel_json(
+            access_token_rx,
+            target.host,
+            target.port,
+            selected_org,
+            target.slug,
+            target_policy,
+            replay_buffered,
+        )
+        .await
+    } else {
+        let mut terminal = setup_terminal()?;
+        let mut app = App::new()?;
+        app.monochrome = !output::styles_enabled();
+        app.state = AppState::Tunneling;
+        app.tunnel_local_host = target.host.clone();
+        app.tunnel_local_port = target.port;
+        app.tunnel_org_id = selected_org.clone();
+        app.tunnel_requested_slug = target.slug.clone();
+
+        let (event_tx, event_rx) = mpsc::channel(tunnel::PRESENTATION_QUEUE_CAPACITY);
+        let reconnect_tx = spawn_tunnel_forwarder_manager(
+            access_token_rx,
+            target.host,
+            target.port,
+            selected_org,
+            target.slug,
+            target_policy,
+            event_tx.clone(),
+            replay_buffered,
+        );
+        let result = run_app(
+            &mut terminal,
+            &mut app,
+            event_rx,
+            Some(reconnect_tx),
+            Some(event_tx),
+            Some(logo::spawn_logo_animation()),
+        )
+        .await;
+        restore_terminal(&mut terminal)?;
+        result
+    }
+}
+
+fn validate_tunnel_target(target: &TunnelTarget) -> Result<()> {
+    if target.port == 0 {
+        return Err(anyhow!("Tunnel target port must be between 1 and 65535"));
+    }
+    if target.host.trim().is_empty() {
+        return Err(anyhow!("Tunnel target host cannot be empty"));
+    }
+    Ok(())
+}
+
+fn print_tunnel_lifecycle_resource<T: serde::Serialize>(
+    json: bool,
+    operation: &str,
+    collection_uri: &str,
+    id: &str,
+    organization_id: &str,
+    resource: &T,
+) -> Result<()> {
+    let resource_uri = format!("{collection_uri}/{id}");
+    let receipt = tunnel_lifecycle_receipt(
+        operation,
+        "succeeded",
+        organization_id,
+        Some(&resource_uri),
+        serde_json::to_value(resource)?,
+    );
+    if json {
+        print_json_line(&receipt)
+    } else {
+        print_status(
+            OutputStatus::Ok,
+            &format!("TUNNEL {}", operation.to_uppercase()),
+        );
+        println!();
+        print_field("RESOURCE", &resource_uri);
+        print_field("ORGANIZATION", organization_id);
+        print_json(resource)
+    }
+}
+
+fn print_tunnel_sessions(sessions: &[api::TunnelSessionResource], organization_id: &str) {
+    print_context("Organization:", organization_id);
+    if sessions.is_empty() {
+        print_empty_state(
+            "NO TUNNEL SESSIONS",
+            "Run `hooklistener tunnel start --port 3000` to activate one.",
+        );
+        return;
+    }
+
+    let mut table = new_table(&["ID", "Status", "Slug", "Mode", "Updated"]);
+    for session in sessions {
+        table.add_row(vec![
+            session.id.clone(),
+            session.status.clone(),
+            session
+                .route
+                .as_ref()
+                .map(|route| route.slug.clone())
+                .unwrap_or_else(|| "-".to_string()),
+            session
+                .route
+                .as_ref()
+                .map(|route| route.mode.clone())
+                .unwrap_or_else(|| "-".to_string()),
+            session.updated_at.clone(),
+        ]);
+    }
+    println!("{table}");
+}
+
+async fn run_tunnel_lifecycle_events(
+    context: &TunnelLifecycleContext,
+    mut options: TunnelEventOptions,
+    json: bool,
+) -> Result<()> {
+    loop {
+        let page = context
+            .client
+            .list_tunnel_events(
+                options.cursor.as_deref(),
+                options.limit,
+                options.capture_id.as_deref(),
+                options.attempt_id.as_deref(),
+            )
+            .await?;
+
+        for event in &page.data {
+            if json {
+                print_json_line(&tunnel_lifecycle_event_envelope(event))?;
+            } else {
+                println!(
+                    "{}  {}  capture={}  attempt={}",
+                    event.position,
+                    event.event_type,
+                    event.capture_id,
+                    event.delivery_id.as_deref().unwrap_or("-")
+                );
+            }
+        }
+
+        options.cursor = Some(page.meta.cursor.clone());
+        if json {
+            print_json_line(&tunnel_lifecycle_receipt(
+                "events",
+                if options.follow {
+                    "following"
+                } else {
+                    "succeeded"
+                },
+                &context.organization_id,
+                Some("hooklistener://tunnel/events"),
+                serde_json::json!({
+                    "cursor": page.meta.cursor,
+                    "has_more": page.meta.has_more,
+                    "retention_days": page.meta.retention_days,
+                    "resync": page.meta.resync,
+                    "event_count": page.data.len(),
+                }),
+            ))?;
+        }
+
+        if !options.follow {
+            return Ok(());
+        }
+        if page.meta.has_more {
+            continue;
+        }
+
+        tokio::select! {
+            signal = tokio::signal::ctrl_c() => {
+                signal?;
+                if json {
+                    print_json_line(&tunnel_lifecycle_receipt(
+                        "events",
+                        "stopped",
+                        &context.organization_id,
+                        Some("hooklistener://tunnel/events"),
+                        serde_json::json!({"cursor": options.cursor}),
+                    ))?;
+                }
+                return Ok(());
+            }
+            _ = sleep(Duration::from_millis(options.interval_ms.max(100))) => {}
+        }
+    }
 }
 
 async fn run_login_flow(force_reauth: bool) -> Result<()> {
@@ -4567,6 +5118,9 @@ fn error_hint(err: &anyhow::Error) -> Option<&str> {
     if let Some(e) = err.downcast_ref::<errors::TunnelError>() {
         return e.hint();
     }
+    if let Some(e) = err.downcast_ref::<errors::TunnelLifecycleError>() {
+        return e.hint();
+    }
     if let Some(e) = err.downcast_ref::<errors::ConfigError>() {
         return e.hint();
     }
@@ -4587,30 +5141,40 @@ fn error_hint(err: &anyhow::Error) -> Option<&str> {
     None
 }
 
-fn error_code(err: &anyhow::Error) -> &'static str {
+fn error_code(err: &anyhow::Error) -> String {
     if err.downcast_ref::<errors::ApiError>().is_some() {
-        "api_error"
+        "api_error".to_string()
     } else if err.downcast_ref::<errors::TunnelError>().is_some() {
-        "tunnel_error"
+        "tunnel_error".to_string()
+    } else if let Some(error) = err.downcast_ref::<errors::TunnelLifecycleError>() {
+        error.code().to_string()
     } else if err.downcast_ref::<errors::ConfigError>().is_some() {
-        "config_error"
+        "config_error".to_string()
     } else if err.downcast_ref::<errors::UpdateError>().is_some() {
-        "update_error"
+        "update_error".to_string()
     } else {
         let message = err.to_string();
         if message.contains("Confirmation required") {
-            "confirmation_required"
+            "confirmation_required".to_string()
         } else if message.contains("does not support --json") {
-            "unsupported_output_mode"
+            "unsupported_output_mode".to_string()
         } else if message.contains("Session expired") || message.contains("No access token") {
-            "authentication_required"
+            "authentication_required".to_string()
         } else if message.contains("No organization selected") {
-            "organization_required"
+            "organization_required".to_string()
         } else if message.contains("Unknown config key") {
-            "invalid_config_key"
+            "invalid_config_key".to_string()
         } else {
-            "command_failed"
+            "command_failed".to_string()
         }
+    }
+}
+
+fn command_exit_code(err: &anyhow::Error) -> i32 {
+    match err.downcast_ref::<errors::TunnelLifecycleError>() {
+        Some(errors::TunnelLifecycleError::IncompatibleSchema { .. }) => 3,
+        Some(errors::TunnelLifecycleError::CursorExpired { .. }) => 4,
+        _ => 1,
     }
 }
 
@@ -4621,13 +5185,31 @@ fn json_error_receipt(err: &anyhow::Error) -> serde_json::Value {
         .map(ToString::to_string)
         .collect::<Vec<_>>();
 
+    let details = match err.downcast_ref::<errors::TunnelLifecycleError>() {
+        Some(errors::TunnelLifecycleError::CursorExpired {
+            earliest_cursor,
+            resync,
+        }) => serde_json::json!({
+            "earliest_cursor": earliest_cursor,
+            "resync": resync,
+        }),
+        Some(errors::TunnelLifecycleError::IncompatibleSchema { supported, actual }) => {
+            serde_json::json!({"supported_major": supported, "actual_major": actual})
+        }
+        _ => serde_json::Value::Null,
+    };
+
     serde_json::json!({
+        "$schema": COMMAND_ERROR_SCHEMA,
+        "schema_version": 1,
+        "type": "error",
         "ok": false,
         "error": {
             "code": error_code(err),
             "message": err.to_string(),
             "hint": error_hint(err),
             "causes": causes,
+            "details": details,
         }
     })
 }
@@ -4635,9 +5217,9 @@ fn json_error_receipt(err: &anyhow::Error) -> serde_json::Value {
 fn display_error(err: &anyhow::Error, json: bool) {
     if json {
         match serde_json::to_string(&json_error_receipt(err)) {
-            Ok(receipt) => eprintln!("{receipt}"),
-            Err(_) => eprintln!(
-                r#"{{"ok":false,"error":{{"code":"serialization_error","message":"Failed to serialize the command error."}}}}"#
+            Ok(receipt) => println!("{receipt}"),
+            Err(_) => println!(
+                r#"{{"$schema":"hooklistener.cli.error/1","schema_version":1,"type":"error","ok":false,"error":{{"code":"serialization_error","message":"Failed to serialize the command error."}}}}"#
             ),
         }
         return;
@@ -4755,14 +5337,256 @@ mod tests {
         }
     }
 
+    fn parsed_tunnel_target(args: &[&str]) -> TunnelTarget {
+        let cli = Cli::try_parse_from(args).expect("tunnel command");
+        match cli.command.expect("parsed command") {
+            Commands::Tunnel {
+                action: None,
+                target,
+            } => target.resolve(),
+            Commands::Tunnel {
+                action:
+                    Some(
+                        TunnelAction::Start(action_target)
+                        | TunnelAction::Activate(action_target)
+                        | TunnelAction::Prepare(action_target),
+                    ),
+                target,
+            } => target.merge(action_target).resolve(),
+            _ => panic!("expected a tunnel target command"),
+        }
+    }
+
     #[test]
     fn json_error_receipt_has_stable_machine_readable_shape() {
         let receipt = json_error_receipt(&anyhow!("Something failed"));
 
+        assert_eq!(receipt["$schema"], COMMAND_ERROR_SCHEMA);
+        assert_eq!(receipt["type"], "error");
         assert_eq!(receipt["ok"], false);
         assert_eq!(receipt["error"]["code"], "command_failed");
         assert_eq!(receipt["error"]["message"], "Something failed");
         assert!(receipt["error"]["causes"].is_array());
+    }
+
+    #[test]
+    fn command_events_declare_document_specific_schemas() {
+        let listen = listen_event_base(
+            "connected",
+            "connected",
+            "endpoint-123",
+            "http://localhost:3000",
+        );
+        let tunnel = tunnel_event_base("connected", "connected");
+
+        assert_eq!(listen["$schema"], LISTEN_EVENT_SCHEMA);
+        assert_eq!(listen["type"], "event");
+        assert_eq!(tunnel["$schema"], TUNNEL_EVENT_SCHEMA);
+        assert_eq!(tunnel["type"], "event");
+    }
+
+    fn lifecycle_contract(major: u64) -> api::TunnelLifecycleContract {
+        api::TunnelLifecycleContract {
+            id: "hooklistener.tunnel.lifecycle".to_string(),
+            version: format!("{major}.0.0"),
+            schema: api::TunnelSchemaVersion { major, minor: 0 },
+            receipts: serde_json::json!({}),
+            events: serde_json::json!({}),
+            resources: serde_json::json!({}),
+            lifecycle: serde_json::json!({}),
+            exit_codes: serde_json::json!({}),
+        }
+    }
+
+    #[test]
+    fn tunnel_lifecycle_subcommands_preserve_default_start_syntax() {
+        let default = Cli::try_parse_from(["hooklistener", "tunnel", "--port", "4000"])
+            .expect("legacy tunnel syntax");
+        assert!(matches!(
+            default.command,
+            Some(Commands::Tunnel {
+                action: None,
+                target: TunnelTargetArgs {
+                    port: Some(4000),
+                    ..
+                }
+            })
+        ));
+
+        let before_start = parsed_tunnel_target(&[
+            "hooklistener",
+            "tunnel",
+            "--port",
+            "4000",
+            "--host",
+            "127.0.0.1",
+            "--org",
+            "org_123",
+            "--slug",
+            "billing",
+            "--allow-non-loopback",
+            "--no-replay-buffered",
+            "start",
+        ]);
+        let after_start = parsed_tunnel_target(&[
+            "hooklistener",
+            "tunnel",
+            "start",
+            "--port",
+            "4000",
+            "--host",
+            "127.0.0.1",
+            "--org",
+            "org_123",
+            "--slug",
+            "billing",
+            "--allow-non-loopback",
+            "--no-replay-buffered",
+        ]);
+        assert_eq!(before_start, after_start);
+        assert_eq!(before_start.port, 4000);
+        assert_eq!(before_start.host, "127.0.0.1");
+        assert_eq!(before_start.org.as_deref(), Some("org_123"));
+        assert_eq!(before_start.slug.as_deref(), Some("billing"));
+        assert!(before_start.allow_non_loopback);
+        assert!(before_start.no_replay_buffered);
+
+        for action in ["prepare", "activate"] {
+            let before =
+                parsed_tunnel_target(&["hooklistener", "tunnel", "--port", "4001", action]);
+            let after = parsed_tunnel_target(&["hooklistener", "tunnel", action, "--port", "4001"]);
+            assert_eq!(before, after);
+        }
+
+        let events = Cli::try_parse_from([
+            "hooklistener",
+            "tunnel",
+            "events",
+            "--cursor",
+            "opaque",
+            "--follow",
+            "--json",
+        ])
+        .expect("events command");
+        assert!(events.json);
+        assert!(matches!(
+            events.command,
+            Some(Commands::Tunnel {
+                action: Some(TunnelAction::Events {
+                    cursor: Some(cursor),
+                    follow: true,
+                    ..
+                }),
+                ..
+            }) if cursor == "opaque"
+        ));
+    }
+
+    #[test]
+    fn tunnel_schema_mismatch_is_typed_before_activation() {
+        let error = validate_tunnel_schema(&lifecycle_contract(2)).unwrap_err();
+
+        assert_eq!(error_code(&error), "incompatible_schema");
+        assert_eq!(command_exit_code(&error), 3);
+        assert_eq!(
+            json_error_receipt(&error)["error"]["details"]["actual_major"],
+            2
+        );
+    }
+
+    #[test]
+    fn expired_tunnel_cursor_has_stable_exit_code_and_resync_details() {
+        let error = anyhow::Error::new(errors::TunnelLifecycleError::CursorExpired {
+            earliest_cursor: Some("earliest".to_string()),
+            resync: serde_json::json!({"sessions": "/api/v1/tunnel/sessions"}),
+        });
+        let receipt = json_error_receipt(&error);
+
+        assert_eq!(error_code(&error), "cursor_expired");
+        assert_eq!(command_exit_code(&error), 4);
+        assert_eq!(receipt["error"]["details"]["earliest_cursor"], "earliest");
+        assert_eq!(
+            receipt["error"]["details"]["resync"]["sessions"],
+            "/api/v1/tunnel/sessions"
+        );
+
+        let without_cursor = anyhow::Error::new(errors::TunnelLifecycleError::CursorExpired {
+            earliest_cursor: None,
+            resync: serde_json::json!({}),
+        });
+        assert_eq!(
+            error_hint(&without_cursor),
+            Some(
+                "Resync sessions, captures, attempts, and outcomes, then request a fresh event cursor."
+            )
+        );
+    }
+
+    #[test]
+    fn tunnel_receipts_are_versioned_and_do_not_expose_credentials() {
+        let receipt = tunnel_lifecycle_receipt(
+            "prepare",
+            "prepared",
+            "org_123",
+            None,
+            serde_json::json!({
+                "local_target_url": "http://localhost:3000",
+                "requested_slug": "billing"
+            }),
+        );
+        let serialized = serde_json::to_string(&receipt).unwrap();
+
+        assert_eq!(receipt["$schema"], TUNNEL_RECEIPT_SCHEMA);
+        assert_eq!(receipt["schema_version"], 1);
+        assert!(receipt["event_id"].is_string());
+        assert_eq!(receipt["sequence"], 0);
+        assert!(!serialized.contains("access_token"));
+        assert!(!serialized.contains("resume_token"));
+    }
+
+    #[test]
+    fn tunnel_event_envelope_carries_cursor_identity_sequence_and_resources() {
+        let event = api::TunnelLifecycleEvent {
+            id: "event_123".to_string(),
+            position: 42,
+            cursor: "opaque-cursor".to_string(),
+            organization_id: "org_123".to_string(),
+            capture_id: "capture_123".to_string(),
+            delivery_id: Some("attempt_123".to_string()),
+            sequence: 3,
+            fence: Some(2),
+            event_type: "forward_started".to_string(),
+            metadata: serde_json::json!({
+                "source": "tunnel",
+                "status_code": 202,
+                "headers": {"authorization": "Bearer secret-header"},
+                "body": "secret-body",
+                "access_token": "secret-access-token",
+                "credentials": {"password": "secret-password"},
+                "error_code": {"token": "secret-nested-token"}
+            }),
+            created_at: "2026-07-14T20:00:00Z".to_string(),
+        };
+
+        let envelope = tunnel_lifecycle_event_envelope(&event);
+
+        assert_eq!(envelope["$schema"], TUNNEL_EVENT_SCHEMA);
+        assert_eq!(envelope["event_id"], "event_123");
+        assert_eq!(envelope["sequence"], 3);
+        assert_eq!(envelope["cursor"], "opaque-cursor");
+        assert_eq!(envelope["metadata"]["source"], "tunnel");
+        assert_eq!(envelope["metadata"]["status_code"], 202);
+        assert!(envelope["metadata"].get("headers").is_none());
+        assert!(envelope["metadata"].get("body").is_none());
+        assert!(envelope["metadata"].get("access_token").is_none());
+        assert!(envelope["metadata"].get("credentials").is_none());
+        assert!(envelope["metadata"].get("error_code").is_none());
+        let serialized = serde_json::to_string(&envelope).unwrap();
+        assert!(!serialized.contains("secret"));
+        assert_eq!(
+            envelope["resources"]["attempt"],
+            "hooklistener://tunnel/attempts/attempt_123"
+        );
     }
 
     #[test]

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -1,3 +1,4 @@
+use crate::api::ApiClient;
 use anyhow::{Context, Result, anyhow};
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use brotli::Decompressor as BrotliDecoder;
@@ -8,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Cursor, Read};
 use std::sync::{
-    Arc,
+    Arc, Mutex,
     atomic::{AtomicU8, AtomicUsize, Ordering},
 };
 use std::time::{Duration, SystemTime};
@@ -1118,12 +1119,18 @@ fn tunnel_join_payload(
     local_port: u16,
     organization_id: Option<&str>,
     slug: Option<&str>,
+    resume_token: Option<&str>,
 ) -> serde_json::Value {
     let mut payload = serde_json::json!({
         "mode": DIRECT_RESPONSE_MODE,
         "protocol_version": TUNNEL_PROTOCOL_VERSION,
         "local_port": local_port,
     });
+
+    if let Some(resume_token) = resume_token {
+        payload["resume_token"] = serde_json::Value::String(resume_token.to_string());
+        return payload;
+    }
 
     if let Some(organization_id) = organization_id {
         payload["organization_id"] = serde_json::Value::String(organization_id.to_string());
@@ -1937,6 +1944,7 @@ pub struct TunnelForwarder {
     event_tx: mpsc::Sender<TunnelEvent>,
     replay_buffered: bool,
     presentation_drops: Arc<AtomicUsize>,
+    resume_session_id: Arc<Mutex<Option<String>>>,
 }
 
 impl TunnelForwarder {
@@ -1965,6 +1973,7 @@ impl TunnelForwarder {
             event_tx,
             replay_buffered,
             presentation_drops: Arc::new(AtomicUsize::new(0)),
+            resume_session_id: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -1986,6 +1995,28 @@ impl TunnelForwarder {
         }
     }
 
+    async fn resume_token(&self, access_token: &str) -> Result<Option<String>> {
+        let session_id = self
+            .resume_session_id
+            .lock()
+            .map_err(|_| anyhow!("Tunnel resume state is unavailable"))?
+            .clone();
+        let Some(session_id) = session_id else {
+            return Ok(None);
+        };
+        let organization_id = self
+            .org_id
+            .clone()
+            .ok_or_else(|| anyhow!("Tunnel resume requires an organization"))?;
+        let client = ApiClient::with_base_url(
+            access_token.to_string(),
+            self.base_url.clone(),
+            Some(organization_id),
+        )?;
+        let descriptor = client.reconnect_tunnel_session(&session_id).await?;
+        Ok(Some(descriptor.resume_token))
+    }
+
     pub async fn connect_and_forward(&self) -> Result<()> {
         info!(
             local_host = %self.local_host,
@@ -1997,6 +2028,7 @@ impl TunnelForwarder {
 
         // Exchange the long-lived HTTP credential for a one-time, scoped handshake ticket.
         let access_token = self.access_token_rx.borrow().clone();
+        let resume_token = self.resume_token(&access_token).await?;
         let plan = serde_json::json!({
             "mode": DIRECT_RESPONSE_MODE,
             "route": {"organization_id": &self.org_id, "slug": &self.slug},
@@ -2051,9 +2083,12 @@ impl TunnelForwarder {
             self.local_port,
             self.org_id.as_deref(),
             self.slug.as_deref(),
+            resume_token.as_deref(),
         );
 
-        if let Some(slug) = &self.slug {
+        if resume_token.is_some() {
+            info!("Resuming canonical tunnel session");
+        } else if let Some(slug) = &self.slug {
             info!(slug = %slug, "Requesting static tunnel");
         }
 
@@ -2090,7 +2125,7 @@ impl TunnelForwarder {
                             && let Some(status) = msg.payload.get("status")
                         {
                             if status == "ok" {
-                                // Extract subdomain, tunnel_id, and static flag from response
+                                // Extract the negotiated contract and canonical session identity.
                                 let Some(response) = msg.payload.get("response") else {
                                     let error = anyhow!("Tunnel join response was missing");
                                     let _ = self
@@ -2131,6 +2166,21 @@ impl TunnelForwarder {
                                         .await;
                                     return Err(error);
                                 }
+
+                                let session_id = response
+                                    .get("session_id")
+                                    .and_then(|id| id.as_str())
+                                    .ok_or_else(|| {
+                                        anyhow!(
+                                            "Tunnel service did not return a canonical session id"
+                                        )
+                                    })?
+                                    .to_string();
+                                *self
+                                    .resume_session_id
+                                    .lock()
+                                    .map_err(|_| anyhow!("Tunnel resume state is unavailable"))? =
+                                    Some(session_id);
 
                                 let subdomain = response
                                     .get("subdomain")
@@ -3117,6 +3167,8 @@ impl TunnelForwarder {
                         return result;
                     }
 
+                    warn!(error = %err_msg, "Tunnel connection attempt failed; retrying");
+
                     if start.elapsed() > Duration::from_secs(5) {
                         attempt = 0;
                     }
@@ -3236,7 +3288,7 @@ mod tests {
     fn test_join_payloads_select_explicit_activation_modes() {
         assert_eq!(listen_join_payload()["mode"], CAPTURE_FORWARD_MODE);
 
-        let tunnel_payload = tunnel_join_payload(3000, Some("org-1"), Some("payments"));
+        let tunnel_payload = tunnel_join_payload(3000, Some("org-1"), Some("payments"), None);
         assert_eq!(tunnel_payload["mode"], DIRECT_RESPONSE_MODE);
         assert_eq!(tunnel_payload["protocol_version"], TUNNEL_PROTOCOL_VERSION);
         assert_eq!(tunnel_payload["local_port"], 3000);
@@ -3450,6 +3502,25 @@ mod tests {
 
         assert_eq!(response.status(), reqwest::StatusCode::FOUND);
         server.await.unwrap();
+    }
+
+    #[test]
+    fn test_tunnel_join_payload_resumes_without_reactivating_route_inputs() {
+        let fresh = tunnel_join_payload(3000, Some("org-123"), Some("billing"), None);
+        assert_eq!(fresh["organization_id"], "org-123");
+        assert_eq!(fresh["slug"], "billing");
+        assert!(fresh.get("resume_token").is_none());
+
+        let resumed = tunnel_join_payload(
+            4000,
+            Some("org-123"),
+            Some("billing"),
+            Some("short-lived-token"),
+        );
+        assert_eq!(resumed["local_port"], 4000);
+        assert_eq!(resumed["resume_token"], "short-lived-token");
+        assert!(resumed.get("organization_id").is_none());
+        assert!(resumed.get("slug").is_none());
     }
 
     #[test]
@@ -3812,6 +3883,45 @@ mod tests {
         forwarder.emit_presentation(TunnelEvent::Disconnected);
 
         assert_eq!(forwarder.presentation_drops.load(Ordering::Acquire), 1);
+    }
+
+    #[tokio::test]
+    async fn test_resume_token_uses_configured_api_base_url() {
+        let mut server = mockito::Server::new_async().await;
+        let reconnect = server
+            .mock("POST", "/api/v1/tunnel/sessions/session-123/reconnect")
+            .match_header("authorization", "Bearer test-token")
+            .match_header("x-organization-id", "org-123")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"session":{"id":"session-123","organization_id":"org-123","status":"active","fence":1,"created_at":"2026-07-14T20:00:00Z","updated_at":"2026-07-14T20:00:01Z","route":null},"topic":"tunnel:connect","resume_token":"short-lived-resume-token","resume_token_expires_in":300,"cursor":"opaque","ownership":"lost"}}"#,
+            )
+            .create_async()
+            .await;
+        let (_token_tx, token_rx) = watch::channel("test-token".to_string());
+        let (event_tx, _event_rx) = mpsc::channel(1);
+        let target = TargetPolicy::resolve("http://127.0.0.1:3000", false, false)
+            .await
+            .unwrap();
+        let mut forwarder = TunnelForwarder::new(
+            token_rx,
+            "127.0.0.1".to_string(),
+            3000,
+            target,
+            Some("org-123".to_string()),
+            None,
+            event_tx,
+            false,
+        );
+        forwarder.base_url = server.url();
+        *forwarder.resume_session_id.lock().unwrap() = Some("session-123".to_string());
+
+        assert_eq!(
+            forwarder.resume_token("test-token").await.unwrap(),
+            Some("short-lived-resume-token".to_string())
+        );
+        reconnect.assert_async().await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- add authenticated `prepare`, `activate`, `start`, `list`, `status`, `events`, `capture`, `attempt`, and `stop` commands while preserving `tunnel --port`
- negotiate schema major 1 before activation and return typed schema/cursor errors with exit codes 3 and 4
- emit versioned NDJSON receipts and per-event cursor envelopes without credentials or captured secrets
- resume canonical relay sessions with cloud-issued tokens and rehydrate lifecycle state after the original process exits
- cover parsing, cloud API auth, redaction, cursor expiry, receipts, event resources, exit codes, and resume payloads

## Verification

- `cargo test` (242 passed)
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`

Depends on [hooklistener_service#147](https://github.com/lemonity-org/hooklistener_service/pull/147), which is stacked on service #143 (LEM-216).

Blocks [LEM-218](https://linear.app/lemonity/issue/LEM-218).

Closes [LEM-224](https://linear.app/lemonity/issue/LEM-224).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive tunnel lifecycle controls (prepare/start, activate, list/status, capture/attempt inspection, stop, reconnect).
  * Enhanced `--json` tunnel/event output with versioned, schema-based envelopes including stable receipts and sequence numbers.
  * Added cursor-based event following with improved rehydration behavior after expired cursors.
  * Enabled automatic tunnel session resume using reconnect flow.
* **Bug Fixes**
  * Improved error reporting for incompatible tunnel schemas and expired event cursors, including actionable details and stable process exit codes.
* **Documentation**
  * Updated README with the full tunnel command workflow and refined automation/cursor/event streaming guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->