### PR TITLE
test(tunnel): add Phase 1 cross-platform gate (LEM-226)

### DIFF
--- a/.github/workflows/tunnel-phase1-conformance.yml
+++ b/.github/workflows/tunnel-phase1-conformance.yml
@@ -1,0 +1,46 @@
+name: Tunnel Phase 1 Conformance
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  platform-conformance:
+    name: Authenticated lifecycle (${{ matrix.platform }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux
+            os: ubuntu-latest
+          - platform: macos
+            os: macos-latest
+          - platform: windows
+            os: windows-latest
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy,rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - name: Validate bounded relay and lifecycle contracts
+        run: cargo test --locked tunnel
+      - name: Run authenticated human and JSON flows
+        env:
+          HOOKLISTENER_CONFORMANCE_OUTPUT: ${{ runner.temp }}/phase1-${{ matrix.platform }}.json
+          HOOKLISTENER_CONFORMANCE_PLATFORM: ${{ matrix.platform }}
+        run: cargo test --locked --test tunnel_phase1_conformance -- --nocapture
+      - name: Upload platform receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: phase1-${{ matrix.platform }}
+          path: ${{ runner.temp }}/phase1-${{ matrix.platform }}.json
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/tunnel-phase1-conformance.md
+++ b/docs/tunnel-phase1-conformance.md
@@ -1,0 +1,23 @@
+# Tunnel Phase 1 conformance
+
+The cross-platform gate runs the public binary as a subprocess on Linux,
+macOS, and Windows. Each runner uses an isolated authenticated configuration
+and a local HTTP contract fixture, then exercises `tunnel prepare` and
+cloud-authoritative `tunnel list` in both human and `--json` modes.
+
+The job first runs the bounded tunnel transport tests, so a platform receipt is
+uploaded only after framing, queue, cancellation, and lifecycle tests pass.
+The service release gate accepts exactly one receipt per supported platform and
+requires `authenticated=true` plus passing human and JSON flows.
+
+Run the same check locally with:
+
+```sh
+cargo test --locked tunnel
+HOOKLISTENER_CONFORMANCE_OUTPUT=tmp/phase1-linux.json \
+HOOKLISTENER_CONFORMANCE_PLATFORM=linux \
+cargo test --locked --test tunnel_phase1_conformance -- --nocapture
+```
+
+Fixtures never contain production credentials or payloads, and both stdout and
+stderr are checked for token disclosure before a receipt is written.

--- a/tests/tunnel_phase1_conformance.rs
+++ b/tests/tunnel_phase1_conformance.rs
@@ -1,0 +1,192 @@
+use mockito::{Matcher, Server};
+use serde_json::{Value, json};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use tempfile::TempDir;
+
+const ACCESS_TOKEN: &str = "phase1-conformance-access-token";
+const ORGANIZATION_ID: &str = "phase1-conformance-organization";
+
+struct TestHome {
+    _temp: TempDir,
+    root: PathBuf,
+    config_root: PathBuf,
+}
+
+impl TestHome {
+    fn new() -> Self {
+        let temp = TempDir::new().expect("create isolated CLI home");
+        let root = temp.path().to_path_buf();
+
+        #[cfg(target_os = "windows")]
+        let config_root = root.join("AppData").join("Roaming");
+        #[cfg(target_os = "macos")]
+        let config_root = root.join("Library").join("Application Support");
+        #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+        let config_root = root.join("config");
+
+        fs::create_dir_all(config_root.join("hooklistener")).expect("create config directory");
+        fs::write(
+            config_root.join("hooklistener").join("config.json"),
+            serde_json::to_vec_pretty(&json!({
+                "access_token": ACCESS_TOKEN,
+                "token_expires_at": "2099-01-01T00:00:00Z",
+                "refresh_token": null,
+                "refresh_token_expires_at": null,
+                "selected_organization_id": ORGANIZATION_ID,
+                "last_update_check": "2099-01-01T00:00:00Z",
+                "latest_known_version": null
+            }))
+            .expect("serialize config"),
+        )
+        .expect("write config");
+
+        Self {
+            _temp: temp,
+            root,
+            config_root,
+        }
+    }
+
+    fn command(&self, api_url: &str, args: &[&str]) -> Output {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_hooklistener"));
+        command
+            .args(["--color", "never", "--log-dir"])
+            .arg(self.root.join("logs"))
+            .args(args)
+            .env("HOOKLISTENER_API_URL", api_url)
+            .env("HOME", &self.root)
+            .env("USERPROFILE", &self.root)
+            .env("APPDATA", &self.config_root)
+            .env("LOCALAPPDATA", &self.config_root)
+            .env("XDG_CONFIG_HOME", &self.config_root)
+            .env("NO_COLOR", "1");
+
+        command.output().expect("run Hooklistener CLI")
+    }
+}
+
+fn assert_success(output: &Output) -> String {
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(
+        output.status.success(),
+        "CLI failed with {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        stdout,
+        stderr
+    );
+    assert!(!stdout.contains(ACCESS_TOKEN));
+    assert!(!stderr.contains(ACCESS_TOKEN));
+    stdout
+}
+
+fn assert_json_receipt(stdout: &str, operation: &str) -> Value {
+    let receipt: Value = serde_json::from_str(stdout.trim()).expect("one valid NDJSON receipt");
+    assert_eq!(receipt["$schema"], "hooklistener.tunnel.receipt/1");
+    assert_eq!(receipt["schema_version"], 1);
+    assert_eq!(receipt["type"], "receipt");
+    assert_eq!(receipt["operation"], operation);
+    assert_eq!(receipt["organization_id"], ORGANIZATION_ID);
+    receipt
+}
+
+fn write_platform_receipt(path: &Path) {
+    let platform = std::env::var("HOOKLISTENER_CONFORMANCE_PLATFORM")
+        .unwrap_or_else(|_| std::env::consts::OS.to_string());
+    let evidence_id = std::env::var("GITHUB_RUN_ID")
+        .map(|run| format!("{run}-{platform}"))
+        .unwrap_or_else(|_| format!("local-{platform}"));
+    let receipt = json!({
+        "$schema": "hooklistener.tunnel.cli-platform-evidence/1",
+        "platform": platform,
+        "status": "passed",
+        "authenticated": true,
+        "flows": {"human": "passed", "json": "passed"},
+        "commands": ["tunnel prepare", "tunnel list"],
+        "contract_schema_major": 1,
+        "evidence_id": evidence_id
+    });
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create receipt directory");
+    }
+    fs::write(
+        path,
+        serde_json::to_vec_pretty(&receipt).expect("serialize receipt"),
+    )
+    .expect("write platform receipt");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn authenticated_human_and_json_lifecycle_flows_emit_platform_evidence() {
+    let mut server = Server::new_async().await;
+    let contract = server
+        .mock("GET", "/api/v1/tunnel/contract")
+        .match_header("authorization", format!("Bearer {ACCESS_TOKEN}").as_str())
+        .match_header("x-organization-id", ORGANIZATION_ID)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"data":{"id":"hooklistener.tunnel.lifecycle","version":"1.0.0","schema":{"major":1,"minor":0},"receipts":{},"events":{},"resources":{},"lifecycle":{},"exit_codes":{}}}"#,
+        )
+        .expect(4)
+        .create_async()
+        .await;
+    let sessions = server
+        .mock("GET", "/api/v1/tunnel/sessions")
+        .match_query(Matcher::Any)
+        .match_header("authorization", format!("Bearer {ACCESS_TOKEN}").as_str())
+        .match_header("x-organization-id", ORGANIZATION_ID)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"data":[],"meta":{"count":0}}"#)
+        .expect(2)
+        .create_async()
+        .await;
+    let home = TestHome::new();
+
+    let human_prepare = assert_success(&home.command(
+        &server.url(),
+        &["tunnel", "prepare", "--port", "3000", "--host", "127.0.0.1"],
+    ));
+    assert!(human_prepare.contains("TUNNEL PREPARED"));
+    assert!(human_prepare.contains("1.0.0"));
+
+    let json_prepare = assert_success(&home.command(
+        &server.url(),
+        &[
+            "--json",
+            "tunnel",
+            "prepare",
+            "--port",
+            "3000",
+            "--host",
+            "127.0.0.1",
+        ],
+    ));
+    assert_eq!(
+        assert_json_receipt(&json_prepare, "prepare")["status"],
+        "prepared"
+    );
+
+    let human_list =
+        assert_success(&home.command(&server.url(), &["tunnel", "list", "--limit", "50"]));
+    assert!(human_list.contains("NO TUNNEL SESSIONS"));
+
+    let json_list = assert_success(&home.command(
+        &server.url(),
+        &["--json", "tunnel", "list", "--limit", "50"],
+    ));
+    let list_receipt = assert_json_receipt(&json_list, "list");
+    assert_eq!(list_receipt["status"], "succeeded");
+    assert_eq!(list_receipt["data"]["data"], json!([]));
+
+    contract.assert_async().await;
+    sessions.assert_async().await;
+
+    if let Some(path) = std::env::var_os("HOOKLISTENER_CONFORMANCE_OUTPUT") {
+        write_platform_receipt(Path::new(&path));
+    }
+}


### PR DESCRIPTION
## Summary

- execute the public binary with isolated authenticated configuration on Linux, macOS, and Windows
- cover both human output and versioned `--json` lifecycle receipts for `tunnel prepare` and cloud-authoritative `tunnel list`
- emit one typed, secret-safe platform receipt only after the bounded relay and lifecycle contract tests pass
- combine the LEM-223 concurrent relay prerequisite with the LEM-224 cloud lifecycle so the gate exercises the actual Phase 1 CLI

## Dependencies

- Base/dependency: #28 (LEM-224 cloud lifecycle)
- Additional dependency: #27 (LEM-223 concurrent relay/output isolation; includes #25 and #24)
- Service conformance/rollout counterpart: https://github.com/lemonity-org/hooklistener_service/pull/148
- Blocks LEM-218 beta integration

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` — 261 passed
- authenticated subprocess receipt generated locally with human and JSON flows passing

Linear: https://linear.app/lemonity/issue/LEM-226/tunnel-build-phase-1-conformance-rollout-and-cross-platform-test
