### PR TITLE
feat(tunnel): Replay buffered requests on connect

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -179,6 +179,10 @@ enum Commands {
         /// Static tunnel slug (paid plans only, creates persistent subdomain)
         #[arg(short, long)]
         slug: Option<String>,
+
+        /// Do not automatically replay requests buffered while the tunnel was offline
+        #[arg(long)]
+        no_replay_buffered: bool,
     },
 }
 
@@ -1215,10 +1219,12 @@ fn tunnel_event_receipt(
             headers,
             body,
             query_string,
+            replay,
         } => {
             let request_resource_uri = request_resource_uri(request_id);
             let mut receipt = tunnel_event_base("request_received", "received");
             receipt["request_id"] = serde_json::json!(request_id);
+            receipt["replay"] = serde_json::json!(replay);
             receipt["resource_uri"] = serde_json::json!(&request_resource_uri);
             receipt["request_resource_uri"] = serde_json::json!(&request_resource_uri);
             receipt["method"] = serde_json::json!(method);
@@ -1298,6 +1304,37 @@ fn tunnel_event_receipt(
             receipt["retryable"] = serde_json::json!(false);
             receipt["next_actions"] = serde_json::json!([
                 "Verify authentication, organization scope, requested slug, and network connectivity."
+            ]);
+            receipt
+        }
+        TunnelEvent::BufferedSummary {
+            count,
+            oldest_captured_at,
+        } => {
+            let mut receipt = tunnel_event_base("buffered_summary", "buffered");
+            receipt["resource_uri"] = serde_json::json!(tunnel_session_resource_uri(host, port));
+            receipt["count"] = serde_json::json!(count);
+            receipt["oldest_captured_at"] = serde_json::json!(oldest_captured_at);
+            receipt
+        }
+        TunnelEvent::BufferedReplayed { capture_id, status } => {
+            let request_resource_uri = request_resource_uri(capture_id);
+            let mut receipt = tunnel_event_base("buffered_replayed", "succeeded");
+            receipt["capture_id"] = serde_json::json!(capture_id);
+            receipt["resource_uri"] = serde_json::json!(&request_resource_uri);
+            receipt["request_resource_uri"] = serde_json::json!(&request_resource_uri);
+            receipt["status_code"] = serde_json::json!(status);
+            receipt
+        }
+        TunnelEvent::BufferedReplayFailed { capture_id, reason } => {
+            let request_resource_uri = request_resource_uri(capture_id);
+            let mut receipt = tunnel_event_base("buffered_replay_failed", "failed");
+            receipt["capture_id"] = serde_json::json!(capture_id);
+            receipt["resource_uri"] = serde_json::json!(&request_resource_uri);
+            receipt["request_resource_uri"] = serde_json::json!(&request_resource_uri);
+            receipt["error"] = serde_json::json!(reason);
+            receipt["next_actions"] = serde_json::json!([
+                "The request stays buffered. Check the local target and reconnect to retry."
             ]);
             receipt
         }
@@ -1670,6 +1707,7 @@ async fn run_tunnel_json(
     port: u16,
     organization_id: Option<String>,
     slug: Option<String>,
+    replay_buffered: bool,
 ) -> Result<()> {
     print_json_line(&tunnel_started_receipt(
         &host,
@@ -1686,6 +1724,7 @@ async fn run_tunnel_json(
         organization_id.clone(),
         slug.clone(),
         event_tx,
+        replay_buffered,
     ));
 
     stream_tunnel_json_events(
@@ -2858,6 +2897,7 @@ async fn run(cli: Cli) -> Result<()> {
             host,
             org,
             slug,
+            no_replay_buffered,
         } => {
             // Initialize logging for tunnel
             let log_config = LogConfig {
@@ -2875,8 +2915,18 @@ async fn run(cli: Cli) -> Result<()> {
             let access_token = ensure_valid_token(&mut config).await?;
             let access_token_rx = refreshed_access_token_rx(access_token, config);
 
+            let replay_buffered = !no_replay_buffered;
+
             if json {
-                run_tunnel_json(access_token_rx, host, port, selected_org, slug).await?;
+                run_tunnel_json(
+                    access_token_rx,
+                    host,
+                    port,
+                    selected_org,
+                    slug,
+                    replay_buffered,
+                )
+                .await?;
             } else {
                 // Setup TUI for tunnel command
                 let mut terminal = setup_terminal()?;
@@ -2902,6 +2952,7 @@ async fn run(cli: Cli) -> Result<()> {
                     selected_org,
                     slug,
                     event_tx.clone(),
+                    replay_buffered,
                 );
 
                 let res = run_app(
@@ -4110,6 +4161,7 @@ fn spawn_tunnel_forwarder_manager(
     org: Option<String>,
     slug: Option<String>,
     event_tx: mpsc::Sender<TunnelEvent>,
+    replay_buffered: bool,
 ) -> mpsc::UnboundedSender<()> {
     let (reconnect_tx, mut reconnect_rx) = mpsc::unbounded_channel::<()>();
 
@@ -4121,6 +4173,7 @@ fn spawn_tunnel_forwarder_manager(
             org.clone(),
             slug.clone(),
             event_tx.clone(),
+            replay_buffered,
         ));
 
         while reconnect_rx.recv().await.is_some() {
@@ -4137,6 +4190,7 @@ fn spawn_tunnel_forwarder_manager(
                 org.clone(),
                 slug.clone(),
                 event_tx.clone(),
+                replay_buffered,
             ));
         }
 
@@ -4154,9 +4208,17 @@ async fn run_tunnel_forwarder_connection(
     org: Option<String>,
     slug: Option<String>,
     event_tx: mpsc::Sender<TunnelEvent>,
+    replay_buffered: bool,
 ) {
-    let tunnel_forwarder =
-        tunnel::TunnelForwarder::new(access_token_rx, host, port, org, slug, event_tx);
+    let tunnel_forwarder = tunnel::TunnelForwarder::new(
+        access_token_rx,
+        host,
+        port,
+        org,
+        slug,
+        event_tx,
+        replay_buffered,
+    );
 
     if let Err(e) = tunnel_forwarder
         .connect_with_reconnect(tunnel::ReconnectConfig::default())
@@ -4263,6 +4325,7 @@ where
                     headers,
                     body,
                     query_string,
+                    replay: _,
                 } => {
                     use std::time::Instant;
                     let tunnel_request = app::TunnelRequest {
@@ -4329,6 +4392,32 @@ where
                     app.set_tunnel_feedback(
                         FeedbackKind::Error,
                         format!("Replay {request_id} failed: {error}"),
+                    );
+                }
+                TunnelEvent::BufferedSummary {
+                    count,
+                    oldest_captured_at: _,
+                } => {
+                    if count > 0 {
+                        app.set_tunnel_feedback(
+                            FeedbackKind::Info,
+                            format!(
+                                "{count} request{} buffered while offline",
+                                if count == 1 { "" } else { "s" }
+                            ),
+                        );
+                    }
+                }
+                TunnelEvent::BufferedReplayed { capture_id, status } => {
+                    app.set_tunnel_feedback(
+                        FeedbackKind::Success,
+                        format!("Replayed buffered {capture_id} → {status}"),
+                    );
+                }
+                TunnelEvent::BufferedReplayFailed { capture_id, reason } => {
+                    app.set_tunnel_feedback(
+                        FeedbackKind::Error,
+                        format!("Buffered replay {capture_id} failed: {reason}"),
                     );
                 }
                 TunnelEvent::ForwardSuccess { .. } => {
@@ -5355,6 +5444,7 @@ mod tests {
             headers,
             body: Some("{\"ok\":true}".to_string()),
             query_string: "delivery=abc".to_string(),
+            replay: false,
         };
         let receipt = tunnel_event_receipt(&event, "127.0.0.1", 8080, None, Some("dev"));
 
@@ -5386,6 +5476,7 @@ mod tests {
             headers,
             body: None,
             query_string: String::new(),
+            replay: false,
         };
 
         let receipt = tunnel_event_receipt(&event, "127.0.0.1", 8080, None, None);
@@ -5427,6 +5518,67 @@ mod tests {
         let output = receipt.to_string();
         assert!(!output.contains("response-secret"));
         assert!(!output.contains("response-token"));
+    }
+
+    #[test]
+    fn buffered_summary_event_receipt_includes_count_and_oldest() {
+        let event = TunnelEvent::BufferedSummary {
+            count: 3,
+            oldest_captured_at: Some("2026-07-14T09:00:00Z".to_string()),
+        };
+
+        let receipt = tunnel_event_receipt(&event, "localhost", 3000, None, None);
+
+        assert_eq!(receipt["event"], "buffered_summary");
+        assert_eq!(receipt["count"], 3);
+        assert_eq!(receipt["oldest_captured_at"], "2026-07-14T09:00:00Z");
+    }
+
+    #[test]
+    fn buffered_replayed_event_receipt_includes_status() {
+        let event = TunnelEvent::BufferedReplayed {
+            capture_id: "cap_123".to_string(),
+            status: 204,
+        };
+
+        let receipt = tunnel_event_receipt(&event, "localhost", 3000, None, None);
+
+        assert_eq!(receipt["event"], "buffered_replayed");
+        assert_eq!(receipt["capture_id"], "cap_123");
+        assert_eq!(receipt["status_code"], 204);
+        assert_eq!(receipt["resource_uri"], "hooklistener://requests/cap_123");
+    }
+
+    #[test]
+    fn buffered_replay_failed_event_receipt_includes_reason() {
+        let event = TunnelEvent::BufferedReplayFailed {
+            capture_id: "cap_123".to_string(),
+            reason: "local_unreachable".to_string(),
+        };
+
+        let receipt = tunnel_event_receipt(&event, "localhost", 3000, None, None);
+
+        assert_eq!(receipt["event"], "buffered_replay_failed");
+        assert_eq!(receipt["capture_id"], "cap_123");
+        assert_eq!(receipt["error"], "local_unreachable");
+    }
+
+    #[test]
+    fn tunnel_request_event_marks_replay() {
+        let event = TunnelEvent::RequestReceived {
+            request_id: "cap_456".to_string(),
+            method: "POST".to_string(),
+            path: "/webhook".to_string(),
+            headers: std::collections::HashMap::new(),
+            body: None,
+            query_string: String::new(),
+            replay: true,
+        };
+
+        let receipt = tunnel_event_receipt(&event, "localhost", 3000, None, None);
+
+        assert_eq!(receipt["event"], "request_received");
+        assert_eq!(receipt["replay"], true);
     }
 
     #[test]

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -197,6 +197,7 @@ pub enum TunnelEvent {
         headers: HashMap<String, String>,
         body: Option<String>,
         query_string: String,
+        replay: bool,
     },
     RequestForwarded {
         request_id: String,
@@ -217,6 +218,18 @@ pub enum TunnelEvent {
     ReplayFailed {
         request_id: String,
         error: String,
+    },
+    BufferedSummary {
+        count: u64,
+        oldest_captured_at: Option<String>,
+    },
+    BufferedReplayed {
+        capture_id: String,
+        status: u16,
+    },
+    BufferedReplayFailed {
+        capture_id: String,
+        reason: String,
     },
     WebhookReceived(Box<crate::models::WebhookRequest>),
     ForwardSuccess {
@@ -902,9 +915,11 @@ pub struct TunnelForwarder {
     slug: Option<String>,
     base_url: String,
     event_tx: mpsc::Sender<TunnelEvent>,
+    replay_buffered: bool,
 }
 
 impl TunnelForwarder {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         access_token_rx: watch::Receiver<String>,
         local_host: String,
@@ -912,6 +927,7 @@ impl TunnelForwarder {
         org_id: Option<String>,
         slug: Option<String>,
         event_tx: mpsc::Sender<TunnelEvent>,
+        replay_buffered: bool,
     ) -> Self {
         let base_url = std::env::var("HOOKLISTENER_API_URL")
             .unwrap_or_else(|_| "https://app.hooklistener.com".to_string());
@@ -924,6 +940,7 @@ impl TunnelForwarder {
             slug,
             base_url,
             event_tx,
+            replay_buffered,
         }
     }
 
@@ -1099,6 +1116,10 @@ impl TunnelForwarder {
         });
         let mut in_flight = tokio::task::JoinSet::new();
 
+        // Auto-drain buffered requests at most once per connection so a
+        // persistently failing replay cannot loop forever.
+        let mut auto_drain_requested = false;
+
         // Track last ping time
         let mut last_ping = tokio::time::Instant::now();
         let ping_interval = Duration::from_secs(30);
@@ -1153,6 +1174,7 @@ impl TunnelForwarder {
                                 &tunnel_topic,
                                 tunnel_limits,
                                 &mut in_flight,
+                                &mut auto_drain_requested,
                             )
                             .await
                         {
@@ -1209,6 +1231,7 @@ impl TunnelForwarder {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn handle_tunnel_message(
         &self,
         text: &str,
@@ -1216,6 +1239,7 @@ impl TunnelForwarder {
         tunnel_topic: &str,
         tunnel_limits: TunnelLimits,
         in_flight: &mut tokio::task::JoinSet<Result<()>>,
+        auto_drain_requested: &mut bool,
     ) -> Result<()> {
         let msg: ChannelMessage = serde_json::from_str(text)?;
 
@@ -1254,6 +1278,10 @@ impl TunnelForwarder {
                         .and_then(|v| v.as_object())
                         .cloned()
                         .unwrap_or_default();
+                    let replay = payload
+                        .get("replay")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
 
                     // Decode body based on body_encoding field
                     let body_encoding = payload
@@ -1307,6 +1335,7 @@ impl TunnelForwarder {
                             headers: headers_map,
                             body: body_string,
                             query_string: query_string.clone(),
+                            replay,
                         })
                         .await;
 
@@ -1333,9 +1362,114 @@ impl TunnelForwarder {
                     });
                 }
             }
+            "buffered_summary" => {
+                let count = msg
+                    .payload
+                    .get("count")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0);
+                let oldest_captured_at = msg
+                    .payload
+                    .get("oldest_captured_at")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string);
+
+                info!(count = count, "Buffered requests waiting on server");
+
+                let _ = self
+                    .event_tx
+                    .send(TunnelEvent::BufferedSummary {
+                        count,
+                        oldest_captured_at,
+                    })
+                    .await;
+
+                if self.replay_buffered && count > 0 && !*auto_drain_requested {
+                    *auto_drain_requested = true;
+
+                    let replay_msg = ChannelMessage {
+                        topic: tunnel_topic.to_string(),
+                        event: "buffered:replay".to_string(),
+                        payload: serde_json::json!({}),
+                        reference: Some("buffered-replay".to_string()),
+                    };
+
+                    let json = serde_json::to_string(&replay_msg)?;
+                    outbound_tx
+                        .send(Message::Text(json.into()))
+                        .await
+                        .context("Failed to send buffered replay request")?;
+                }
+            }
+            "buffered_replayed" => {
+                let capture_id = msg
+                    .payload
+                    .get("capture_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown")
+                    .to_string();
+                let status = msg
+                    .payload
+                    .get("status")
+                    .and_then(|v| v.as_u64())
+                    .and_then(|v| u16::try_from(v).ok())
+                    .unwrap_or(0);
+
+                let _ = self
+                    .event_tx
+                    .send(TunnelEvent::BufferedReplayed { capture_id, status })
+                    .await;
+            }
+            "buffered_replay_failed" => {
+                let capture_id = msg
+                    .payload
+                    .get("capture_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown")
+                    .to_string();
+                let reason = msg
+                    .payload
+                    .get("reason")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown")
+                    .to_string();
+
+                let _ = self
+                    .event_tx
+                    .send(TunnelEvent::BufferedReplayFailed { capture_id, reason })
+                    .await;
+            }
             "phx_reply" => {
-                // Handle ping replies
-                if let Some(response) = msg.payload.get("response")
+                if msg.reference.as_deref() == Some("buffered-replay") {
+                    // Reply to our buffered:replay drain request
+                    let status = msg
+                        .payload
+                        .get("status")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+
+                    if status != "ok" {
+                        let reason = msg
+                            .payload
+                            .get("response")
+                            .and_then(|r| r.get("reason"))
+                            .and_then(|r| r.as_str())
+                            .unwrap_or("unknown")
+                            .to_string();
+
+                        // An empty buffer is not an error worth surfacing.
+                        if reason != "buffer_empty" {
+                            warn!(reason = %reason, "Buffered replay request rejected");
+                            let _ = self
+                                .event_tx
+                                .send(TunnelEvent::BufferedReplayFailed {
+                                    capture_id: "unknown".to_string(),
+                                    reason,
+                                })
+                                .await;
+                        }
+                    }
+                } else if let Some(response) = msg.payload.get("response")
                     && response
                         .get("pong")
                         .and_then(|v| v.as_bool())


### PR DESCRIPTION
## What

When a static tunnel with offline buffering reconnects, the CLI now automatically replays every request that was buffered on Hooklistener while it was offline — no need to keep the CLI running 24/7.

## How it works

- On join, the server pushes `buffered_summary` (`count`, `oldest_captured_at`). If count > 0, the CLI sends a single `buffered:replay` and the server drains the buffer oldest-first through the normal `tunnel_request` path, so the existing forwarding code delivers replays to localhost unchanged.
- Auto-drain fires **at most once per connection**, so a persistently failing replay can't loop; failed captures stay buffered server-side and retry on the next reconnect.
- Opt out with `hooklistener tunnel --no-replay-buffered`.

## UX

- **TUI**: status-line feedback — "N requests buffered while offline", "Replayed buffered cap_x → 200", failures as errors.
- **JSON mode**: new `buffered_summary`, `buffered_replayed`, `buffered_replay_failed` receipts; `request_received` receipts now include `"replay": true/false`.
- Replayed requests carry `hooklistener-replay: true` and `hooklistener-original-timestamp` headers so local servers can distinguish them.

## Testing

- `cargo fmt`, `cargo clippy`, `cargo test` (245 passed), including 5 new receipt tests
- Live E2E against the local service: 3 webhooks buffered while offline (202) → CLI connect → `buffered_summary count=3` → auto-drain in order (n=1,2,3) → all delivered with original bodies/query strings and replay headers → `buffered_summary count=0`. Live traffic while connected unaffected.