### PR TITLE
feat(tunnel): launch authenticated beta (LEM-218)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ hooklistener tunnel stop <session-id> --reason "deployment complete"
 
 `hooklistener tunnel --port 3000` remains an alias for `tunnel start`. Every lifecycle command negotiates the authenticated tunnel contract first; an incompatible schema major fails before relay activation.
 
+`tunnel` and `listen` are authenticated beta relay modes and require an organization enabled by Hooklistener. Every connection exchanges the account credential for a short-lived, single-use ticket scoped to its mode, route, organization, and pinned target. Anonymous endpoints are a separate capture workflow and cannot activate either relay mode. See [the authenticated beta guide](docs/tunnel-authenticated-beta.md) for limits, safe diagnostics, and support guidance.
+
 ## Work with captured requests
 
 Select an organization once for account-backed commands:

--- a/docs/tunnel-authenticated-beta.md
+++ b/docs/tunnel-authenticated-beta.md
@@ -1,0 +1,62 @@
+# Authenticated tunnel beta
+
+The beta exposes two explicit relay modes to signed-in users whose organization
+is in the server-managed cohort:
+
+- `hooklistener tunnel start --port 3000` gives the public caller the local
+  handler's response.
+- `hooklistener listen <endpoint> --target http://localhost:3000` forwards an
+  already captured endpoint request. The endpoint's configured response, not
+  the local handler's response, remains public.
+
+Run `hooklistener login`, select the intended organization with
+`hooklistener org use <organization-id>`, and use `hooklistener tunnel prepare
+--port 3000` to verify authentication, schema compatibility, target resolution,
+and the activation plan before starting a direct-response relay.
+
+## Lifecycle and diagnostics
+
+Cloud-authoritative state remains available when the original CLI process is
+gone:
+
+```text
+hooklistener tunnel list
+hooklistener tunnel status <session-id>
+hooklistener tunnel events --cursor <cursor> --follow
+hooklistener tunnel capture <capture-id>
+hooklistener tunnel attempt <attempt-id>
+hooklistener tunnel stop <session-id> --reason "deployment complete"
+```
+
+Use `--json` for noninteractive NDJSON receipts and events. Persist opaque event
+cursors; if a cursor expires, rehydrate the resources named by the error before
+continuing. Support requests should include the safe session, capture, attempt,
+outcome, and event identifiers, plus `hooklistener --version` and the operating
+system. Do not include account credentials, relay tickets, resume tokens, raw
+headers, queries, bodies, or local target details.
+
+## Relay security
+
+Each WebSocket connection obtains a new short-lived, single-use relay ticket.
+The ticket is bound to the activation mode, organization and route, and a target
+plan containing the resolved addresses. The CLI pins those addresses, ignores
+proxy environment variables, and does not follow redirects.
+
+Targets are loopback-only unless `--allow-non-loopback` is supplied for an
+explicitly trusted host. `listen` also requires a visible `--insecure-tls` flag
+to disable HTTPS certificate verification. Target credentials, query strings,
+fragments, invalid schemes, and forbidden addresses are rejected before relay
+activation.
+
+## Phase 1 boundaries
+
+Direct-response transport uses protocol version 2, bounded 64 KiB frames,
+per-frame acknowledgement, bounded work and response queues, advertised body
+and header limits, and one end-to-end deadline. Capture-forward reads only an
+already durable capture through a scoped, audited grant.
+
+The beta does not promise anonymous tunnels, WebSocket upgrades, HTTP trailers,
+public sharing, stable public API compatibility, MCP exposure, or unattended
+agent autonomy. A server rollback can reject activation or stop dispatch to an
+existing client; retain the safe typed error and retry only after the cohort is
+restored. There is no legacy relay fallback.

--- a/src/main.rs
+++ b/src/main.rs
@@ -6321,6 +6321,7 @@ mod tests {
     fn tunnel_request_event_includes_local_target_and_request_resource() {
         let mut headers = std::collections::HashMap::new();
         headers.insert("content-type".to_string(), "application/json".to_string());
+        headers.insert("authorization".to_string(), "Bearer secret".to_string());
         let event = TunnelEvent::RequestReceived {
             request_id: "req_123".to_string(),
             method: "POST".to_string(),
@@ -6340,6 +6341,8 @@ mod tests {
         );
         assert_eq!(receipt["body_size"], 11);
         assert_eq!(receipt["headers"]["content-type"], "application/json");
+        assert_eq!(receipt["headers"]["authorization"], "[REDACTED]");
+        assert!(!receipt.to_string().contains("Bearer secret"));
     }
 
     #[test]

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -310,15 +310,11 @@ struct LocalDelivery {
 
 impl LocalDelivery {
     fn retained_bytes(&self) -> usize {
+        // This semaphore is the retained body budget. Request count is bounded
+        // separately, while request metadata has protocol and HTTP ingress
+        // limits of its own. Including metadata here would reject a body that
+        // is exactly at the server-advertised limit.
         self.body.len()
-            + self.method.len()
-            + self.path.len()
-            + self.query_string.len()
-            + self
-                .headers
-                .iter()
-                .map(|(name, value)| name.len() + value.len())
-                .sum::<usize>()
     }
 
     fn received_event(&self) -> TunnelEvent {
@@ -3734,6 +3730,21 @@ mod tests {
     #[test]
     fn test_local_work_budget_allows_one_advertised_limit_body() {
         let budget = LocalWorkBudget::new();
+        let delivery = LocalDelivery {
+            request_id: "request-at-limit".to_string(),
+            method: "POST".to_string(),
+            path: "/metadata-does-not-reduce-the-body-budget".to_string(),
+            query_string: "source=conformance".to_string(),
+            headers: vec![(
+                "content-type".to_string(),
+                "application/octet-stream".to_string(),
+            )],
+            body: Vec::new(),
+            deadline_unix_ms: unix_time_ms() + 1_000,
+            replay: false,
+        };
+        assert_eq!(delivery.retained_bytes(), 0);
+
         let permit = budget.try_acquire(LOCAL_WORK_MAX_BYTES).unwrap();
 
         assert_eq!(budget.available_bytes(), 0);
@@ -3790,9 +3801,7 @@ mod tests {
     #[test]
     fn test_response_buffer_allows_one_advertised_limit_body() {
         let budget = ResponseBufferBudget::new();
-        let permit = budget
-            .try_reserve(Some(RESPONSE_BUFFER_MAX_BYTES))
-            .unwrap();
+        let permit = budget.try_reserve(Some(RESPONSE_BUFFER_MAX_BYTES)).unwrap();
 
         assert_eq!(budget.available_bytes(), 0);
         assert!(budget.try_reserve(Some(1)).is_none());

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -458,16 +458,7 @@ fn should_forward_request_header(key: &str) -> bool {
 }
 
 fn supported_tunnel_method(method: &str) -> Option<reqwest::Method> {
-    match method {
-        "GET" => Some(reqwest::Method::GET),
-        "POST" => Some(reqwest::Method::POST),
-        "PUT" => Some(reqwest::Method::PUT),
-        "DELETE" => Some(reqwest::Method::DELETE),
-        "PATCH" => Some(reqwest::Method::PATCH),
-        "HEAD" => Some(reqwest::Method::HEAD),
-        "OPTIONS" => Some(reqwest::Method::OPTIONS),
-        _ => None,
-    }
+    reqwest::Method::from_bytes(method.as_bytes()).ok()
 }
 
 fn response_headers_to_map(headers: &reqwest::header::HeaderMap) -> HashMap<String, String> {
@@ -3356,13 +3347,17 @@ mod tests {
     }
 
     #[test]
-    fn test_supported_tunnel_method_rejects_extension_methods() {
+    fn test_supported_tunnel_method_accepts_token_valid_extension_methods() {
         assert_eq!(supported_tunnel_method("GET"), Some(reqwest::Method::GET));
         assert_eq!(
             supported_tunnel_method("OPTIONS"),
             Some(reqwest::Method::OPTIONS)
         );
-        assert_eq!(supported_tunnel_method("PURGE"), None);
+        assert_eq!(
+            supported_tunnel_method("PURGE"),
+            Some(reqwest::Method::from_bytes(b"PURGE").unwrap())
+        );
+        assert_eq!(supported_tunnel_method("BAD METHOD"), None);
     }
 
     #[test]

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -43,10 +43,10 @@ const MAX_RAW_BODY_BYTES: usize = 1_048_576;
 const UI_BODY_PREVIEW_BYTES: usize = 65_536;
 const REDACTED_SECRET: &str = "[REDACTED]";
 const LOCAL_WORK_MAX_COUNT: usize = 8;
-const LOCAL_WORK_MAX_BYTES: usize = 64 * 1024 * 1024;
+const LOCAL_WORK_MAX_BYTES: usize = 256 * 1024 * 1024;
 const INBOUND_STREAM_MAX_COUNT: usize = 16;
-const INBOUND_STREAM_MAX_BYTES: usize = 64 * 1024 * 1024;
-const RESPONSE_BUFFER_MAX_BYTES: usize = 64 * 1024 * 1024;
+const INBOUND_STREAM_MAX_BYTES: usize = TUNNEL_MAX_WEBSOCKET_MESSAGE_BYTES;
+const RESPONSE_BUFFER_MAX_BYTES: usize = 256 * 1024 * 1024;
 const OUTBOUND_CONTROL_MAX_COUNT: usize = 256;
 const OUTBOUND_RESPONSE_MAX_COUNT: usize = 256;
 const OUTBOUND_MAX_BYTES: usize = 4 * 1024 * 1024;
@@ -3717,19 +3717,28 @@ mod tests {
     fn test_local_work_budget_bounds_concurrent_ten_megabyte_deliveries() {
         let budget = LocalWorkBudget::new();
         let ten_mib = 10 * 1024 * 1024;
-        let mut permits = Vec::new();
+        let permits = (0..LOCAL_WORK_MAX_COUNT)
+            .map(|_| budget.try_acquire(ten_mib).unwrap())
+            .collect::<Vec<_>>();
 
-        for _ in 0..6 {
-            permits.push(budget.try_acquire(ten_mib).unwrap());
-        }
-
-        assert_eq!(budget.available_count(), LOCAL_WORK_MAX_COUNT - 6);
-        assert_eq!(budget.available_bytes(), 4 * 1024 * 1024);
+        assert_eq!(budget.available_count(), 0);
         assert!(budget.try_acquire(ten_mib).is_none());
-        assert_eq!(budget.available_count(), LOCAL_WORK_MAX_COUNT - 6);
 
-        permits.pop();
-        assert!(budget.try_acquire(ten_mib).is_some());
+        drop(permits);
+        assert_eq!(budget.available_count(), LOCAL_WORK_MAX_COUNT);
+        assert_eq!(budget.available_bytes(), LOCAL_WORK_MAX_BYTES);
+    }
+
+    #[test]
+    fn test_local_work_budget_allows_one_advertised_limit_body() {
+        let budget = LocalWorkBudget::new();
+        let permit = budget.try_acquire(LOCAL_WORK_MAX_BYTES).unwrap();
+
+        assert_eq!(budget.available_bytes(), 0);
+        assert!(budget.try_acquire(1).is_none());
+
+        drop(permit);
+        assert_eq!(budget.available_bytes(), LOCAL_WORK_MAX_BYTES);
     }
 
     #[test]
@@ -3765,14 +3774,28 @@ mod tests {
     fn test_response_buffer_budget_bounds_concurrent_ten_megabyte_responses() {
         let budget = ResponseBufferBudget::new();
         let ten_mib = 10 * 1024 * 1024;
-        let permits = (0..6)
+        let permits = (0..25)
             .map(|_| budget.try_reserve(Some(ten_mib)).unwrap())
             .collect::<Vec<_>>();
 
-        assert_eq!(budget.available_bytes(), 4 * 1024 * 1024);
+        assert_eq!(budget.available_bytes(), 6 * 1024 * 1024);
         assert!(budget.try_reserve(Some(ten_mib)).is_none());
 
         drop(permits);
+        assert_eq!(budget.available_bytes(), RESPONSE_BUFFER_MAX_BYTES);
+    }
+
+    #[test]
+    fn test_response_buffer_allows_one_advertised_limit_body() {
+        let budget = ResponseBufferBudget::new();
+        let permit = budget
+            .try_reserve(Some(RESPONSE_BUFFER_MAX_BYTES))
+            .unwrap();
+
+        assert_eq!(budget.available_bytes(), 0);
+        assert!(budget.try_reserve(Some(1)).is_none());
+
+        drop(permit);
         assert_eq!(budget.available_bytes(), RESPONSE_BUFFER_MAX_BYTES);
     }
 

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -1881,6 +1881,7 @@ impl TunnelClient {
                 }
                 Err(ref e) => {
                     let err_msg = e.to_string();
+                    warn!(error = %err_msg, "Tunnel connection attempt failed");
                     if is_fatal_error(&err_msg) {
                         let _ = self
                             .event_tx
@@ -3159,6 +3160,7 @@ impl TunnelForwarder {
                 }
                 Err(ref e) => {
                     let err_msg = e.to_string();
+                    warn!(error = %err_msg, "Tunnel connection attempt failed");
                     if is_fatal_error(&err_msg) {
                         let _ = self
                             .event_tx


### PR DESCRIPTION
## Summary

- add authenticated beta onboarding and operational guidance to the public CLI docs
- use a fresh scoped, single-use relay ticket for every connection and reconnect
- enforce pinned loopback target policy, redirect blocking, one end-to-end deadline, and advertised relay limits
- preserve bounded concurrent delivery at the 256 MiB boundary and redact sensitive headers from JSON receipts
- emit actionable reconnect failure diagnostics without exposing credentials

## Dependencies

This is a stacked PR based on [LEM-226 / PR #29](https://github.com/hooklistener/hooklistener-cli/pull/29).

It also incorporates the prerequisite relay and lifecycle stacks:

- [LEM-222 / PR #26](https://github.com/hooklistener/hooklistener-cli/pull/26)
- [LEM-223 / PR #27](https://github.com/hooklistener/hooklistener-cli/pull/27)
- [LEM-224 / PR #28](https://github.com/hooklistener/hooklistener-cli/pull/28)
- [LEM-218 service companion / PR #150](https://github.com/lemonity-org/hooklistener_service/pull/150)

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` — 269 passed (268 unit + 1 integration)
- canonical service/CLI release gate — 71/71 live scenarios; log safety passed
- authoritative routing load — 77 successful completions, 13/13 owner-loss recoveries, 13/13 stale-completion rejections
- Phase 1 storage and recovery gates — 4 concurrent 10 MiB writes and 8/8 fault boundaries

## Linear

[LEM-218: Tunnel: launch the authenticated beta](https://linear.app/lemonity/issue/LEM-218/tunnel-launch-the-authenticated-beta)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for authenticated tunnel and listen beta modes, including setup, diagnostics, limits, security, and failure behavior.
  * Expanded supported HTTP methods, including custom extension methods such as `PURGE`.
  * Increased relay buffering limits to support payloads up to 256 MiB.

* **Bug Fixes**
  * Improved sensitive header handling so authorization values are redacted from tunnel request receipts.
  * Refined request buffering accounting to apply limits more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->