### PR TITLE
feat(tunnel): add anonymous route workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,21 @@ remote target. HTTPS certificate verification can be disabled only with the visi
 
 ### Try it without logging in
 
-Create a temporary anonymous endpoint:
+Expose localhost directly with a bounded 15-minute anonymous route:
+
+```bash
+hooklistener anon tunnel --port 3000 --name stable-demo
+```
+
+Save the route and claim tokens printed before the live view starts. After
+signing in, move the stable name into your organization without transferring
+any pre-claim captures:
+
+```bash
+hooklistener anon claim <route-id> --token <claim-token> --org <organization-id>
+```
+
+To create a capture-only temporary endpoint instead:
 
 ```bash
 hooklistener anon create --ttl 3600
@@ -65,6 +79,7 @@ The result includes the endpoint URL, endpoint ID, and viewer token needed to in
 | --- | --- | --- |
 | Forward an existing Hooklistener endpoint | `hooklistener listen` | Events already arrive at Hooklistener and should be forwarded to your local app |
 | Expose a local server | `hooklistener tunnel` | A provider needs a public URL that points directly to localhost |
+| Expose localhost without signing in | `hooklistener anon tunnel` | You need a bounded temporary relay and can accept reduced limits |
 | Inspect and replay captured requests | `hooklistener endpoint` | You need stored payloads, headers, and forwarding history |
 | Run saved endpoint cases | `hooklistener cases` | You want to replay a repeatable test suite against a URL or saved target |
 | Create a temporary endpoint | `hooklistener anon` | You need a short-lived capture URL without an account |
@@ -93,12 +108,13 @@ hooklistener tunnel status <session-id>
 hooklistener tunnel events --cursor <cursor> --follow
 hooklistener tunnel capture <capture-id>
 hooklistener tunnel attempt <attempt-id>
+hooklistener tunnel detach <session-id> --reason "switching machines"
 hooklistener tunnel stop <session-id> --reason "deployment complete"
 ```
 
 `hooklistener tunnel --port 3000` remains an alias for `tunnel start`. Every lifecycle command negotiates the authenticated tunnel contract first; an incompatible schema major fails before relay activation.
 
-`tunnel` and `listen` are authenticated beta relay modes and require an organization enabled by Hooklistener. Every connection exchanges the account credential for a short-lived, single-use ticket scoped to its mode, route, organization, and pinned target. Anonymous endpoints are a separate capture workflow and cannot activate either relay mode. See [the authenticated beta guide](docs/tunnel-authenticated-beta.md) for limits, safe diagnostics, and support guidance.
+`tunnel` and `listen` are authenticated beta relay modes and require an organization enabled by Hooklistener. Every connection exchanges the account credential for a short-lived, single-use ticket scoped to its mode, route, organization, and pinned target. `anon tunnel` uses a separate public bootstrap with a 1 MiB body limit, per-route request limits, short expiry, and no authenticated capture access. See [the authenticated beta guide](docs/tunnel-authenticated-beta.md) and [the anonymous route guide](docs/tunnel-anonymous-routes.md).
 
 ## Work with captured requests
 
@@ -162,6 +178,7 @@ Long-running `listen --json` and `tunnel --json` commands emit newline-delimited
 ```bash
 hooklistener --json listen <endpoint-slug>
 hooklistener --json tunnel --port 3000
+hooklistener --json anon tunnel --port 3000 --ttl 900
 hooklistener --json tunnel events --cursor <cursor> --follow
 ```
 

--- a/docs/tunnel-anonymous-routes.md
+++ b/docs/tunnel-anonymous-routes.md
@@ -1,0 +1,63 @@
+# Anonymous tunnel routes
+
+Start a public direct-response tunnel without signing in:
+
+```text
+hooklistener anon tunnel --port 3000
+hooklistener anon tunnel --port 3000 --name stable-demo --ttl 1200
+```
+
+The CLI resolves and pins the target with the same loopback-first policy as an
+authenticated tunnel. Anonymous routes last 15 minutes by default and accept a
+TTL from 60 to 1,800 seconds. The service allows three active routes per source
+IP, five creations per hour, 60 requests per minute per route, and request
+bodies up to 1 MiB. Normal framing, response, header, address-pinning, and
+deadline limits still apply.
+
+The creation receipt prints two long-lived credentials once:
+
+- The route token obtains a new short-lived, single-use relay ticket whenever
+  the CLI reconnects. It does not authorize claim.
+- The claim token moves the name into an authenticated organization. It does
+  not authorize a relay connection.
+
+Do not put either token in command logs, issue reports, URLs, or source control.
+Machine mode emits the creation receipt followed by the normal tunnel NDJSON
+event stream:
+
+```text
+hooklistener --json anon tunnel --port 3000 --ttl 900
+```
+
+## Claim a stable name
+
+Save the route ID and claim token, sign in, then run:
+
+```text
+hooklistener anon claim <route-id> --token <claim-token> --org <organization-id>
+```
+
+Claim is atomic. It discards all pre-claim captures and creates the same name as
+an authenticated static reservation. The receipt always reports zero captures
+transferred. A collision rolls the operation back, so the old anonymous route
+does not partially change ownership. Invalid IDs and claim tokens are
+non-enumerable.
+
+After claim, start the name through the authenticated path:
+
+```text
+hooklistener tunnel start --slug stable-demo --port 3000
+```
+
+## Detach and recover
+
+To hand an authenticated stable session to another CLI without closing its
+route, run:
+
+```text
+hooklistener tunnel detach <session-id> --reason "switching machines"
+```
+
+Detach fences the old connection and preserves the route and canonical session.
+The next authorized activation reacquires it with a newer fence. Use `tunnel
+stop` when the session and ephemeral route should become terminal instead.

--- a/docs/tunnel-authenticated-beta.md
+++ b/docs/tunnel-authenticated-beta.md
@@ -25,6 +25,7 @@ hooklistener tunnel status <session-id>
 hooklistener tunnel events --cursor <cursor> --follow
 hooklistener tunnel capture <capture-id>
 hooklistener tunnel attempt <attempt-id>
+hooklistener tunnel detach <session-id> --reason "switching machines"
 hooklistener tunnel stop <session-id> --reason "deployment complete"
 ```
 
@@ -55,8 +56,9 @@ per-frame acknowledgement, bounded work and response queues, advertised body
 and header limits, and one end-to-end deadline. Capture-forward reads only an
 already durable capture through a scoped, audited grant.
 
-The beta does not promise anonymous tunnels, WebSocket upgrades, HTTP trailers,
-public sharing, stable public API compatibility, MCP exposure, or unattended
-agent autonomy. A server rollback can reject activation or stop dispatch to an
-existing client; retain the safe typed error and retry only after the cohort is
-restored. There is no legacy relay fallback.
+Anonymous tunnels use the separate bounded workflow documented in
+`docs/tunnel-anonymous-routes.md`. The beta does not promise WebSocket upgrades,
+HTTP trailers, public sharing, stable public API compatibility, MCP exposure,
+or unattended agent autonomy. A server rollback can reject activation or stop
+dispatch to an existing authenticated client; retain the safe typed error and
+retry only after the cohort is restored. There is no legacy relay fallback.

--- a/src/api.rs
+++ b/src/api.rs
@@ -32,12 +32,35 @@ pub struct Organization {
     pub name: String,
 }
 
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct RelayTicket {
     pub ticket: String,
     pub scope: String,
     pub plan_fingerprint: String,
     pub expires_at: String,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct AnonymousTunnelRouteCreated {
+    pub id: String,
+    pub slug: String,
+    pub url: String,
+    pub stable_name: bool,
+    pub expires_at: String,
+    pub route_token: String,
+    pub claim_token: String,
+    pub relay_ticket: RelayTicket,
+    pub limits: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClaimedAnonymousTunnelRoute {
+    pub id: String,
+    pub slug: String,
+    pub kind: String,
+    pub status: String,
+    pub claimed_at: String,
+    pub privacy: Value,
 }
 
 #[derive(Deserialize)]
@@ -742,9 +765,17 @@ impl ApiClient {
 
     /// Create a client with no authentication (for anonymous endpoints).
     pub fn unauthenticated() -> Result<Self> {
+        Self::unauthenticated_at(default_base_url())
+    }
+
+    pub fn unauthenticated_at(base_url: String) -> Result<Self> {
         Ok(Self {
             client: Client::new(),
-            base_url: Some(default_base_url()),
+            base_url: Some(
+                base_url
+                    .replacen("wss://", "https://", 1)
+                    .replacen("ws://", "http://", 1),
+            ),
         })
     }
 
@@ -785,6 +816,14 @@ impl ApiClient {
             client,
             base_url: Some(base_url),
         })
+    }
+
+    #[cfg(test)]
+    pub fn with_unauthenticated_base_url(base_url: String) -> Self {
+        Self {
+            client: Client::new(),
+            base_url: Some(base_url),
+        }
     }
 
     fn api_url(&self, path: &str) -> Result<String> {
@@ -1188,6 +1227,71 @@ impl ApiClient {
         Ok(response.data)
     }
 
+    pub async fn detach_tunnel_session(
+        &self,
+        id: &str,
+        reason: Option<&str>,
+    ) -> Result<TunnelSessionResource> {
+        let response: DataResponse<TunnelSessionResource> = self
+            .post_tunnel_json(
+                &format!("/api/v1/tunnel/sessions/{id}/detach"),
+                &serde_json::json!({"reason": reason}),
+                "detach tunnel session",
+            )
+            .await?;
+        Ok(response.data)
+    }
+
+    pub async fn create_anonymous_tunnel_route(
+        &self,
+        target: &Value,
+        name: Option<&str>,
+        ttl_seconds: u64,
+    ) -> Result<AnonymousTunnelRouteCreated> {
+        let response: DataResponse<AnonymousTunnelRouteCreated> = self
+            .post_tunnel_json(
+                "/api/v1/tunnel/anonymous-routes",
+                &serde_json::json!({
+                    "target": target,
+                    "name": name,
+                    "ttl_seconds": ttl_seconds,
+                }),
+                "create anonymous tunnel route",
+            )
+            .await?;
+        Ok(response.data)
+    }
+
+    pub async fn issue_anonymous_tunnel_ticket(
+        &self,
+        id: &str,
+        route_token: &str,
+    ) -> Result<RelayTicket> {
+        let response: DataResponse<RelayTicket> = self
+            .post_tunnel_json(
+                &format!("/api/v1/tunnel/anonymous-routes/{id}/relay-tickets"),
+                &serde_json::json!({"route_token": route_token}),
+                "rotate anonymous tunnel relay ticket",
+            )
+            .await?;
+        Ok(response.data)
+    }
+
+    pub async fn claim_anonymous_tunnel_route(
+        &self,
+        id: &str,
+        claim_token: &str,
+    ) -> Result<ClaimedAnonymousTunnelRoute> {
+        let response: DataResponse<ClaimedAnonymousTunnelRoute> = self
+            .post_tunnel_json(
+                &format!("/api/v1/tunnel/anonymous-routes/{id}/claim"),
+                &serde_json::json!({"claim_token": claim_token}),
+                "claim anonymous tunnel route",
+            )
+            .await?;
+        Ok(response.data)
+    }
+
     pub async fn reconnect_tunnel_session(&self, id: &str) -> Result<TunnelReconnectDescriptor> {
         let response: DataResponse<TunnelReconnectDescriptor> = self
             .post_tunnel_json(
@@ -1555,6 +1659,122 @@ mod tests {
 
         assert!(error.to_string().contains("Relay handshake rejected"));
         assert!(error.to_string().contains("HTTP 401 Unauthorized"));
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn anonymous_tunnel_api_bootstraps_rotates_and_claims_without_mixing_credentials() {
+        let mut server = mockito::Server::new_async().await;
+        let create_mock = server
+            .mock("POST", "/api/v1/tunnel/anonymous-routes")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "name": "stable-demo",
+                "ttl_seconds": 900,
+                "target": {"host": "localhost", "port": 3000}
+            })))
+            .with_status(201)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"id":"anon-123","slug":"stable-demo","url":"https://stable-demo.hook.events","stable_name":true,"expires_at":"2026-07-14T20:15:00Z","route_token":"hkar_route-secret","claim_token":"hkac_claim-secret","relay_ticket":{"ticket":"hktr_first","scope":"relay:tunnel","plan_fingerprint":"first-fingerprint","expires_at":"2026-07-14T20:01:00Z"},"limits":{"body_bytes":1048576}}}"#,
+            )
+            .create_async()
+            .await;
+        let rotate_mock = server
+            .mock(
+                "POST",
+                "/api/v1/tunnel/anonymous-routes/anon-123/relay-tickets",
+            )
+            .match_body(mockito::Matcher::Json(serde_json::json!({
+                "route_token": "hkar_route-secret"
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"ticket":"hktr_second","scope":"relay:tunnel","plan_fingerprint":"second-fingerprint","expires_at":"2026-07-14T20:02:00Z"}}"#,
+            )
+            .create_async()
+            .await;
+        let claim_mock = server
+            .mock("POST", "/api/v1/tunnel/anonymous-routes/anon-123/claim")
+            .match_header("authorization", "Bearer access-secret")
+            .match_header("x-organization-id", "org-123")
+            .match_body(mockito::Matcher::Json(serde_json::json!({
+                "claim_token": "hkac_claim-secret"
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"id":"route-claimed","slug":"stable-demo","kind":"static","status":"active","claimed_at":"2026-07-14T20:03:00Z","privacy":{"pre_claim_captures_discarded":true,"captures_transferred":0}}}"#,
+            )
+            .create_async()
+            .await;
+
+        let public = ApiClient::with_unauthenticated_base_url(server.url());
+        let created = public
+            .create_anonymous_tunnel_route(
+                &serde_json::json!({"host": "localhost", "port": 3000}),
+                Some("stable-demo"),
+                900,
+            )
+            .await
+            .unwrap();
+        assert_eq!(created.route_token, "hkar_route-secret");
+        assert_eq!(created.claim_token, "hkac_claim-secret");
+
+        let rotated = public
+            .issue_anonymous_tunnel_ticket(&created.id, &created.route_token)
+            .await
+            .unwrap();
+        assert_eq!(rotated.ticket, "hktr_second");
+
+        let authenticated = ApiClient::with_base_url(
+            "access-secret".to_string(),
+            server.url(),
+            Some("org-123".to_string()),
+        )
+        .unwrap();
+        let claimed = authenticated
+            .claim_anonymous_tunnel_route(&created.id, &created.claim_token)
+            .await
+            .unwrap();
+        assert_eq!(claimed.kind, "static");
+        assert_eq!(claimed.privacy["captures_transferred"], 0);
+
+        create_mock.assert_async().await;
+        rotate_mock.assert_async().await;
+        claim_mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn detach_tunnel_session_posts_reason_and_returns_preserved_route() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/api/v1/tunnel/sessions/session-123/detach")
+            .match_header("authorization", "Bearer test-token")
+            .match_header("x-organization-id", "org-123")
+            .match_body(mockito::Matcher::Json(serde_json::json!({
+                "reason": "switching machines"
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"id":"session-123","organization_id":"org-123","status":"active","fence":2,"created_at":"2026-07-14T20:00:00Z","updated_at":"2026-07-14T20:00:01Z","route":{"id":"route-123","slug":"stable-demo","kind":"static","mode":"direct_response","status":"active","expires_at":null}}}"#,
+            )
+            .create_async()
+            .await;
+        let client = ApiClient::with_base_url(
+            "test-token".to_string(),
+            server.url(),
+            Some("org-123".to_string()),
+        )
+        .unwrap();
+
+        let session = client
+            .detach_tunnel_session("session-123", Some("switching machines"))
+            .await
+            .unwrap();
+        assert_eq!(session.fence, 2);
+        assert_eq!(session.route.unwrap().status, "active");
         mock.assert_async().await;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -302,6 +302,14 @@ enum TunnelAction {
         #[arg(long)]
         org: Option<String>,
     },
+    /// Detach the current owner while preserving the route for recovery
+    Detach {
+        session_id: String,
+        #[arg(long)]
+        reason: Option<String>,
+        #[arg(long)]
+        org: Option<String>,
+    },
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -553,6 +561,32 @@ enum AnonAction {
         /// Viewer token (returned when the endpoint was created)
         #[arg(long)]
         token: String,
+    },
+    /// Expose a local HTTP server without signing in
+    Tunnel {
+        /// Local port to forward requests to
+        #[arg(short, long, default_value = "3000")]
+        port: u16,
+        /// Local host to forward to
+        #[arg(long, default_value = "localhost")]
+        host: String,
+        /// Optional stable public route name
+        #[arg(long)]
+        name: Option<String>,
+        /// Route lifetime in seconds
+        #[arg(long, default_value = "900", value_parser = clap::value_parser!(u64).range(60..=1800))]
+        ttl: u64,
+        /// Allow forwarding to a host that resolves outside loopback
+        #[arg(long)]
+        allow_non_loopback: bool,
+    },
+    /// Claim an anonymous route into an authenticated organization
+    Claim {
+        route_id: String,
+        #[arg(long)]
+        token: String,
+        #[arg(long)]
+        org: Option<String>,
     },
 }
 
@@ -1869,6 +1903,7 @@ async fn stream_tunnel_json_events(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_tunnel_json(
     access_token_rx: watch::Receiver<String>,
     host: String,
@@ -1877,6 +1912,7 @@ async fn run_tunnel_json(
     slug: Option<String>,
     target: target_policy::TargetPolicy,
     replay_buffered: bool,
+    anonymous_route: Option<(String, String, Option<api::RelayTicket>)>,
 ) -> Result<()> {
     print_json_line(&tunnel_started_receipt(
         &host,
@@ -1895,6 +1931,7 @@ async fn run_tunnel_json(
         target,
         event_tx,
         replay_buffered,
+        anonymous_route,
     ));
 
     stream_tunnel_json_events(
@@ -2729,6 +2766,53 @@ async fn run(cli: Cli) -> Result<()> {
                     print_anon_event_detail(&event);
                 }
             }
+            AnonAction::Tunnel {
+                port,
+                host,
+                name,
+                ttl,
+                allow_non_loopback,
+            } => {
+                run_anonymous_tunnel_activation(host, port, name, ttl, allow_non_loopback, json)
+                    .await?;
+            }
+            AnonAction::Claim {
+                route_id,
+                token,
+                org,
+            } => {
+                let mut config = config::Config::load()?;
+                let organization_id = require_organization(org, &config)?;
+                let access_token = ensure_valid_token(&mut config).await?;
+                let client =
+                    ApiClient::with_organization(access_token, Some(organization_id.clone()))?;
+                let claimed = client
+                    .claim_anonymous_tunnel_route(&route_id, &token)
+                    .await?;
+
+                if json {
+                    print_json(&serde_json::json!({
+                        "operation": "claim_anonymous_tunnel",
+                        "status": "succeeded",
+                        "organization_id": organization_id,
+                        "route": claimed,
+                    }))?;
+                } else {
+                    print_status(OutputStatus::Ok, "ANONYMOUS ROUTE CLAIMED");
+                    println!();
+                    print_field("ROUTE", claimed.id);
+                    print_field(
+                        "PUBLIC URL",
+                        format!("https://{}.hook.events", claimed.slug),
+                    );
+                    print_field("ORGANIZATION", organization_id.dim());
+                    print_field("CAPTURES TRANSFERRED", "0");
+                    print_field(
+                        "PRIVACY",
+                        "Pre-claim captures were permanently discarded.".dim(),
+                    );
+                }
+            }
         },
         Commands::Share { action } => match action {
             ShareAction::Create {
@@ -3349,6 +3433,25 @@ async fn run_tunnel_lifecycle_command(
                 &session,
             )
         }
+        Some(TunnelAction::Detach {
+            session_id,
+            reason,
+            org,
+        }) => {
+            let context = tunnel_lifecycle_context(org).await?;
+            let session = context
+                .client
+                .detach_tunnel_session(&session_id, reason.as_deref())
+                .await?;
+            print_tunnel_lifecycle_resource(
+                json,
+                "detach",
+                "hooklistener://tunnel/sessions",
+                &session.id,
+                &context.organization_id,
+                &session,
+            )
+        }
         Some(TunnelAction::Events {
             cursor,
             limit,
@@ -3396,6 +3499,7 @@ async fn run_tunnel_activation(target: TunnelTarget, json: bool) -> Result<()> {
             target.slug,
             target_policy,
             replay_buffered,
+            None,
         )
         .await
     } else {
@@ -3418,6 +3522,128 @@ async fn run_tunnel_activation(target: TunnelTarget, json: bool) -> Result<()> {
             target_policy,
             event_tx.clone(),
             replay_buffered,
+            None,
+        );
+        let result = run_app(
+            &mut terminal,
+            &mut app,
+            event_rx,
+            Some(reconnect_tx),
+            Some(event_tx),
+            Some(logo::spawn_logo_animation()),
+        )
+        .await;
+        restore_terminal(&mut terminal)?;
+        result
+    }
+}
+
+async fn run_anonymous_tunnel_activation(
+    host: String,
+    port: u16,
+    name: Option<String>,
+    ttl: u64,
+    allow_non_loopback: bool,
+    json: bool,
+) -> Result<()> {
+    let target = TunnelTarget {
+        port,
+        host: host.clone(),
+        org: None,
+        slug: name.clone(),
+        allow_non_loopback,
+        no_replay_buffered: true,
+    };
+    validate_tunnel_target(&target)?;
+    let local_target_url = local_tunnel_target_url(&host, port);
+    let target_policy =
+        target_policy::TargetPolicy::resolve(&local_target_url, allow_non_loopback, false).await?;
+    let client = ApiClient::unauthenticated()?;
+    let target_plan = serde_json::to_value(target_policy.plan())?;
+    let created = client
+        .create_anonymous_tunnel_route(&target_plan, name.as_deref(), ttl)
+        .await?;
+
+    if json {
+        print_json_line(&serde_json::json!({
+            "schema": "hooklistener.tunnel.anonymous-route/1",
+            "operation": "create_anonymous_tunnel",
+            "status": "created",
+            "route": {
+                "id": created.id,
+                "slug": created.slug,
+                "url": created.url,
+                "stable_name": created.stable_name,
+                "expires_at": created.expires_at,
+                "limits": created.limits,
+            },
+            "credentials": {
+                "route_token": created.route_token,
+                "claim_token": created.claim_token,
+            },
+            "privacy": {
+                "claim_transfers_captures": false,
+            }
+        }))?;
+    } else {
+        print_status(OutputStatus::Ok, "ANONYMOUS TUNNEL CREATED");
+        println!();
+        print_field("ROUTE", &created.id);
+        print_field("PUBLIC URL", created.url.as_str().underlined());
+        print_field("EXPIRES AT", created.expires_at.as_str().dim());
+        println!();
+        print_field("ROUTE TOKEN", created.route_token.as_str().yellow());
+        print_field("CLAIM TOKEN", created.claim_token.as_str().yellow());
+        print_field(
+            "ACTION",
+            format!(
+                "Save both tokens. Claim later with `hooklistener anon claim {} --token <claim-token>`.",
+                created.id
+            )
+            .dim(),
+        );
+    }
+
+    let anonymous_route = Some((
+        created.id.clone(),
+        created.route_token.clone(),
+        Some(created.relay_ticket.clone()),
+    ));
+    let (_token_tx, token_rx) = watch::channel(String::new());
+
+    if json {
+        run_tunnel_json(
+            token_rx,
+            host,
+            port,
+            None,
+            Some(created.slug),
+            target_policy,
+            false,
+            anonymous_route,
+        )
+        .await
+    } else {
+        let mut terminal = setup_terminal()?;
+        let mut app = App::new()?;
+        app.monochrome = !output::styles_enabled();
+        app.state = AppState::Tunneling;
+        app.tunnel_local_host = host.clone();
+        app.tunnel_local_port = port;
+        app.tunnel_org_id = None;
+        app.tunnel_requested_slug = Some(created.slug.clone());
+
+        let (event_tx, event_rx) = mpsc::channel(tunnel::PRESENTATION_QUEUE_CAPACITY);
+        let reconnect_tx = spawn_tunnel_forwarder_manager(
+            token_rx,
+            host,
+            port,
+            None,
+            Some(created.slug),
+            target_policy,
+            event_tx.clone(),
+            false,
+            anonymous_route,
         );
         let result = run_app(
             &mut terminal,
@@ -4758,10 +4984,14 @@ fn spawn_tunnel_forwarder_manager(
     target: target_policy::TargetPolicy,
     event_tx: mpsc::Sender<TunnelEvent>,
     replay_buffered: bool,
+    anonymous_route: Option<(String, String, Option<api::RelayTicket>)>,
 ) -> mpsc::UnboundedSender<()> {
     let (reconnect_tx, mut reconnect_rx) = mpsc::unbounded_channel::<()>();
 
     tokio::spawn(async move {
+        let reconnect_anonymous_route = anonymous_route
+            .as_ref()
+            .map(|(id, token, _ticket)| (id.clone(), token.clone(), None));
         let mut worker = tokio::spawn(run_tunnel_forwarder_connection(
             access_token_rx.clone(),
             host.clone(),
@@ -4771,6 +5001,7 @@ fn spawn_tunnel_forwarder_manager(
             target.clone(),
             event_tx.clone(),
             replay_buffered,
+            anonymous_route.clone(),
         ));
 
         while reconnect_rx.recv().await.is_some() {
@@ -4789,6 +5020,7 @@ fn spawn_tunnel_forwarder_manager(
                 target.clone(),
                 event_tx.clone(),
                 replay_buffered,
+                reconnect_anonymous_route.clone(),
             ));
         }
 
@@ -4809,8 +5041,9 @@ async fn run_tunnel_forwarder_connection(
     target: target_policy::TargetPolicy,
     event_tx: mpsc::Sender<TunnelEvent>,
     replay_buffered: bool,
+    anonymous_route: Option<(String, String, Option<api::RelayTicket>)>,
 ) {
-    let tunnel_forwarder = tunnel::TunnelForwarder::new(
+    let mut tunnel_forwarder = tunnel::TunnelForwarder::new(
         access_token_rx,
         host,
         port,
@@ -4820,6 +5053,11 @@ async fn run_tunnel_forwarder_connection(
         event_tx,
         replay_buffered,
     );
+
+    if let Some((route_id, route_token, initial_ticket)) = anonymous_route {
+        tunnel_forwarder =
+            tunnel_forwarder.with_anonymous_route(route_id, route_token, initial_ticket);
+    }
 
     if let Err(e) = tunnel_forwarder
         .connect_with_reconnect(tunnel::ReconnectConfig::default())
@@ -5480,6 +5718,78 @@ mod tests {
                 ..
             }) if cursor == "opaque"
         ));
+    }
+
+    #[test]
+    fn anonymous_tunnel_claim_and_detach_commands_parse_explicit_credentials() {
+        let anonymous = Cli::try_parse_from([
+            "hooklistener",
+            "anon",
+            "tunnel",
+            "--port",
+            "4000",
+            "--name",
+            "stable-demo",
+            "--ttl",
+            "1200",
+        ])
+        .expect("anonymous tunnel command");
+        assert!(matches!(
+            anonymous.command,
+            Some(Commands::Anon {
+                action: AnonAction::Tunnel {
+                    port: 4000,
+                    name: Some(name),
+                    ttl: 1200,
+                    ..
+                }
+            }) if name == "stable-demo"
+        ));
+
+        let claim = Cli::try_parse_from([
+            "hooklistener",
+            "anon",
+            "claim",
+            "route-123",
+            "--token",
+            "hkac_secret",
+            "--org",
+            "org-123",
+        ])
+        .expect("anonymous claim command");
+        assert!(matches!(
+            claim.command,
+            Some(Commands::Anon {
+                action: AnonAction::Claim {
+                    route_id,
+                    token,
+                    org: Some(org),
+                }
+            }) if route_id == "route-123" && token == "hkac_secret" && org == "org-123"
+        ));
+
+        let detach = Cli::try_parse_from([
+            "hooklistener",
+            "tunnel",
+            "detach",
+            "session-123",
+            "--reason",
+            "switching-machines",
+        ])
+        .expect("tunnel detach command");
+        assert!(matches!(
+            detach.command,
+            Some(Commands::Tunnel {
+                action: Some(TunnelAction::Detach {
+                    session_id,
+                    reason: Some(reason),
+                    ..
+                }),
+                ..
+            }) if session_id == "session-123" && reason == "switching-machines"
+        ));
+
+        assert!(Cli::try_parse_from(["hooklistener", "anon", "tunnel", "--ttl", "59"]).is_err());
     }
 
     #[test]

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -1933,6 +1933,14 @@ pub struct TunnelForwarder {
     replay_buffered: bool,
     presentation_drops: Arc<AtomicUsize>,
     resume_session_id: Arc<Mutex<Option<String>>>,
+    anonymous_route: Option<AnonymousRouteCredential>,
+}
+
+#[derive(Clone)]
+pub struct AnonymousRouteCredential {
+    route_id: String,
+    route_token: String,
+    initial_ticket: Arc<Mutex<Option<api::RelayTicket>>>,
 }
 
 impl TunnelForwarder {
@@ -1962,7 +1970,22 @@ impl TunnelForwarder {
             replay_buffered,
             presentation_drops: Arc::new(AtomicUsize::new(0)),
             resume_session_id: Arc::new(Mutex::new(None)),
+            anonymous_route: None,
         }
+    }
+
+    pub fn with_anonymous_route(
+        mut self,
+        route_id: String,
+        route_token: String,
+        initial_ticket: Option<api::RelayTicket>,
+    ) -> Self {
+        self.anonymous_route = Some(AnonymousRouteCredential {
+            route_id,
+            route_token,
+            initial_ticket: Arc::new(Mutex::new(initial_ticket)),
+        });
+        self
     }
 
     fn emit_presentation(&self, event: TunnelEvent) {
@@ -1984,6 +2007,10 @@ impl TunnelForwarder {
     }
 
     async fn resume_token(&self, access_token: &str) -> Result<Option<String>> {
+        if self.anonymous_route.is_some() {
+            return Ok(None);
+        }
+
         let session_id = self
             .resume_session_id
             .lock()
@@ -2017,12 +2044,32 @@ impl TunnelForwarder {
         // Exchange the long-lived HTTP credential for a one-time, scoped handshake ticket.
         let access_token = self.access_token_rx.borrow().clone();
         let resume_token = self.resume_token(&access_token).await?;
-        let plan = serde_json::json!({
-            "mode": DIRECT_RESPONSE_MODE,
-            "route": {"organization_id": &self.org_id, "slug": &self.slug},
-            "target": self.target.plan(),
-        });
-        let relay_ticket = api::issue_relay_ticket(&access_token, &self.base_url, &plan).await?;
+        let relay_ticket = if let Some(anonymous_route) = &self.anonymous_route {
+            let initial_ticket = anonymous_route
+                .initial_ticket
+                .lock()
+                .map_err(|_| anyhow!("Anonymous tunnel credential state is unavailable"))?
+                .take();
+
+            match initial_ticket {
+                Some(ticket) => ticket,
+                None => {
+                    ApiClient::unauthenticated_at(self.base_url.clone())?
+                        .issue_anonymous_tunnel_ticket(
+                            &anonymous_route.route_id,
+                            &anonymous_route.route_token,
+                        )
+                        .await?
+                }
+            }
+        } else {
+            let plan = serde_json::json!({
+                "mode": DIRECT_RESPONSE_MODE,
+                "route": {"organization_id": &self.org_id, "slug": &self.slug},
+                "target": self.target.plan(),
+            });
+            api::issue_relay_ticket(&access_token, &self.base_url, &plan).await?
+        };
         if relay_ticket.scope != "relay:tunnel" {
             return Err(anyhow!(
                 "Relay handshake rejected: ticket returned an incompatible scope"


### PR DESCRIPTION
## Summary

- add `hooklistener anon tunnel` with optional stable names and bounded TTLs
- rotate one-time anonymous relay tickets across automatic and manual reconnects
- add authenticated `anon claim` and `tunnel detach` commands with human and NDJSON receipts

## Validation

- `cargo fmt --check`
- `cargo check --locked`
- `cargo test --locked` (271 unit tests and 1 conformance test)
- live CLI/service/local-target forwarding smoke test

## Dependencies

- Depends on #31 (LEM-218 authenticated beta)
- Depends on [service PR #152](https://github.com/lemonity-org/hooklistener_service/pull/152)

Linear: [LEM-219](https://linear.app/lemonity/issue/LEM-219/tunnel-add-anonymous-routes-stable-names-claim-and-detach)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `hooklistener anon tunnel` to expose a local HTTP service without signing in.
  - Added `hooklistener anon claim` to claim an anonymous route with a stable name.
  - Added `hooklistener tunnel detach` to transfer an active tunnel session with an optional reason.
  - Added JSON output support for anonymous tunnel workflows.

- **Documentation**
  - Documented anonymous routes, tokens, limits, claiming, session transfer, and beta workflow boundaries.
  - Added command examples and guidance for choosing the appropriate tunnel workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->