### PR TITLE
chore(release): Prepare v1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1202,7 +1202,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hooklistener-cli"
-version = "1.6.1"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hooklistener-cli"
-version = "1.6.1"
+version = "1.7.0"
 edition = "2024"
 autobins = false
 description = "A fast, terminal-based CLI for browsing webhooks, forwarding events, and exposing local servers"

--- a/npm/packages/hooklistener/package.json
+++ b/npm/packages/hooklistener/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hooklistener",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "A fast, terminal-based CLI for browsing webhooks, forwarding events, and exposing local servers",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

- Bump the Rust crate from 1.6.1 to 1.7.0.
- Keep the Cargo lockfile and npm wrapper version aligned.
- Prepare the tag-driven release for the merged tunnel feature set.

## Validation

- `cargo fmt --all -- --check`
- Strict Clippy across all targets and features
- 321 unit tests plus 1 Phase 1 conformance test
- Optimized release build reports `hooklistener 1.7.0`
- Cargo package verification and npm package dry-run
- Cargo audit with the existing `RUSTSEC-2026-0190` exclusion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the product and package version to 1.7.0.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->