### PR TITLE
security: address CLI audit findings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,9 @@ jobs:
           mkdir -p target/dist
 
           if [[ "${{ matrix.archive }}" == "zip" ]]; then
-            7z a "target/dist/${binary_name}-${{ matrix.target }}.zip" "target/${{ matrix.target }}/release/${binary_name}"
+            pushd "target/${{ matrix.target }}/release"
+            7z a "../../dist/${binary_name}-${{ matrix.target }}.zip" "${binary_name}"
+            popd
           else
             tar -czf "target/dist/${binary_name}-${{ matrix.target }}.tar.gz" -C "target/${{ matrix.target }}/release" "${binary_name}"
           fi
@@ -175,10 +177,26 @@ jobs:
 
       - name: Extract checksums
         id: checksums
+        shell: bash
         run: |
-          ARM64_SHA=$(grep "aarch64-apple-darwin" SHA256SUMS.txt | awk '{print $1}')
-          X86_64_SHA=$(grep "x86_64-apple-darwin" SHA256SUMS.txt | awk '{print $1}')
-          LINUX_SHA=$(grep "x86_64-unknown-linux-gnu" SHA256SUMS.txt | awk '{print $1}')
+          set -euo pipefail
+
+          extract_checksum() {
+            local asset_name="$1"
+            local checksum
+            checksum=$(awk -v asset_name="$asset_name" '$2 == asset_name { print $1 }' SHA256SUMS.txt)
+
+            if [[ ! "$checksum" =~ ^[a-f0-9]{64}$ ]]; then
+              echo "::error::Expected exactly one valid SHA-256 entry for ${asset_name}" >&2
+              return 1
+            fi
+
+            printf '%s\n' "$checksum"
+          }
+
+          ARM64_SHA=$(extract_checksum "hooklistener-aarch64-apple-darwin.tar.gz")
+          X86_64_SHA=$(extract_checksum "hooklistener-x86_64-apple-darwin.tar.gz")
+          LINUX_SHA=$(extract_checksum "hooklistener-x86_64-unknown-linux-gnu.tar.gz")
 
           echo "arm64=$ARM64_SHA" >> $GITHUB_OUTPUT
           echo "x86_64=$X86_64_SHA" >> $GITHUB_OUTPUT

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ Thumbs.db
 *.su
 *.idb
 *.pdb
+hooklistener-diagnostics-*/
 
 # OS specific
 .DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,6 +468,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,6 +547,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +623,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csscolorparser"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,9 +648,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -687,7 +720,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -738,8 +771,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -818,7 +862,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "subtle",
  "zeroize",
@@ -1280,6 +1324,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2184,7 +2237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2842,6 +2895,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "tar",
  "tempfile",
  "ureq",
@@ -2918,8 +2972,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2929,8 +2983,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2985,7 +3050,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -3260,7 +3325,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "phf",
- "sha2",
+ "sha2 0.10.9",
  "signal-hook",
  "siphasher",
  "terminfo",
@@ -3991,7 +4056,7 @@ checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
  "getrandom 0.3.4",
  "mac_address",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ thiserror = "2.0"
 arboard = "3.6"
 comfy-table = "7"
 zstd = "0.13"
-self_update = { version = "1.0.0-rc.2", default-features = false, features = ["reqwest", "native-tls", "github", "progress-bar", "archive-tar", "archive-zip", "compression-tar-gz", "compression-zip-deflate"] }
+self_update = { version = "1.0.0-rc.2", default-features = false, features = ["reqwest", "native-tls", "github", "progress-bar", "checksums", "archive-tar", "archive-zip", "compression-tar-gz", "compression-zip-deflate"] }
 
 [dev-dependencies]
 insta = "1.47"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Hooklistener CLI combines live terminal views with scriptable commands for forwa
 
 Prebuilt binaries are available on the [Releases page](https://github.com/hooklistener/hooklistener-cli/releases). You can also use the install scripts for [macOS or Linux](https://raw.githubusercontent.com/hooklistener/hooklistener-cli/main/scripts/install.sh) and [Windows PowerShell](https://raw.githubusercontent.com/hooklistener/hooklistener-cli/main/scripts/install.ps1).
 
+Every prebuilt-binary installer and the self-updater require the archive to match its exact entry in the release's `SHA256SUMS.txt`. These co-hosted checksums detect corrupted or mismatched assets, but they do not authenticate a release if GitHub publishing credentials are compromised. That remaining risk requires a signed checksum manifest and an independently managed public key; release signing is not configured yet.
+
 Verify the installation:
 
 ```bash
@@ -222,7 +224,9 @@ Inspect the active configuration with:
 hooklistener config show
 ```
 
-Advanced and self-hosted setups can override the service URLs with `HOOKLISTENER_API_URL`, `HOOKLISTENER_WS_URL`, and `HOOKLISTENER_DEVICE_PORTAL_URL`.
+Advanced and self-hosted setups can override the service URLs with `HOOKLISTENER_API_URL`, `HOOKLISTENER_WS_URL`, and `HOOKLISTENER_DEVICE_PORTAL_URL`. Hooklistener API and relay overrides require `https://` and `wss://` respectively. Cleartext `http://` and `ws://` are accepted automatically only for loopback development servers such as `localhost` or `127.0.0.1`.
+
+For an isolated development environment that cannot use TLS on a non-loopback host, opt in explicitly with `--allow-insecure-dev-server` or `HOOKLISTENER_ALLOW_INSECURE_DEV_SERVER=1`. The CLI prints a warning because this exposes credentials and relay tickets to interception; never use this opt-in for production services.
 
 ## Documentation
 

--- a/hooklistener-diagnostics-20260529-130757/config.json
+++ b/hooklistener-diagnostics-20260529-130757/config.json
@@ -1,8 +1,0 @@
-{
-  "last_update_check": "2026-05-28T13:48:00.845822031Z",
-  "latest_known_version": "1.0.1",
-  "refresh_token": "pHtIU-An7prcetCj5Gmm9__hhF1-AKcs1JTmbwvR15w",
-  "refresh_token_expires_at": "2026-06-28T09:44:20.349566026Z",
-  "selected_organization_id": "20b09d0f-727d-4b08-a510-712816661723",
-  "token_expires_at": "[REDACTED]"
-}

--- a/hooklistener-diagnostics-20260529-130757/system_info.json
+++ b/hooklistener-diagnostics-20260529-130757/system_info.json
@@ -1,8 +1,0 @@
-{
-  "arch": "x86_64",
-  "os": "linux",
-  "rust_version": "unknown",
-  "session_id": "cbeff353-c88a-42b2-bc64-72a89fe8f74d",
-  "timestamp": "2026-05-29T13:07:57.676844595+00:00",
-  "version": "1.1.0"
-}

--- a/hooklistener-diagnostics-20260529-130811/config.json
+++ b/hooklistener-diagnostics-20260529-130811/config.json
@@ -1,8 +1,0 @@
-{
-  "last_update_check": "2026-05-28T13:48:00.845822031Z",
-  "latest_known_version": "1.0.1",
-  "refresh_token": "pHtIU-An7prcetCj5Gmm9__hhF1-AKcs1JTmbwvR15w",
-  "refresh_token_expires_at": "2026-06-28T09:44:20.349566026Z",
-  "selected_organization_id": "20b09d0f-727d-4b08-a510-712816661723",
-  "token_expires_at": "[REDACTED]"
-}

--- a/hooklistener-diagnostics-20260529-130811/system_info.json
+++ b/hooklistener-diagnostics-20260529-130811/system_info.json
@@ -1,8 +1,0 @@
-{
-  "arch": "x86_64",
-  "os": "linux",
-  "rust_version": "unknown",
-  "session_id": "b954b60c-3627-479b-9481-99cebba327e3",
-  "timestamp": "2026-05-29T13:08:11.393057778+00:00",
-  "version": "1.1.0"
-}

--- a/npm/packages/hooklistener/scripts/install.js
+++ b/npm/packages/hooklistener/scripts/install.js
@@ -3,12 +3,23 @@
 "use strict";
 
 const https = require("https");
+const crypto = require("crypto");
 const fs = require("fs");
 const path = require("path");
-const { execSync } = require("child_process");
+const { execFileSync } = require("child_process");
 const os = require("os");
 
 const REPO = "hooklistener/hooklistener-cli";
+const CHECKSUM_MANIFEST_MAX_BYTES = 64 * 1024;
+const POWERSHELL_EXPAND_ARCHIVE_SCRIPT = [
+  "param(",
+  "  [Parameter(Mandatory=$true, Position=0)][string]$ArchivePath,",
+  "  [Parameter(Mandatory=$true, Position=1)][string]$DestinationPath",
+  ")",
+  'Set-StrictMode -Version "Latest"',
+  '$ErrorActionPreference = "Stop"',
+  "Expand-Archive -LiteralPath $ArchivePath -DestinationPath $DestinationPath -Force",
+].join("\r\n");
 
 const PLATFORM_MAP = {
   "linux-x64": { target: "x86_64-unknown-linux-gnu", archive: "tar.gz" },
@@ -26,18 +37,27 @@ function getPackageVersion() {
   return JSON.parse(fs.readFileSync(pkgPath, "utf8")).version;
 }
 
-function download(url) {
+function download(url, maxBytes = Number.POSITIVE_INFINITY) {
   return new Promise((resolve, reject) => {
     https
       .get(url, { headers: { "User-Agent": "hooklistener-npm" } }, (res) => {
         if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-          return download(res.headers.location).then(resolve, reject);
+          return download(res.headers.location, maxBytes).then(resolve, reject);
         }
         if (res.statusCode !== 200) {
           return reject(new Error(`HTTP ${res.statusCode} for ${url}`));
         }
         const chunks = [];
-        res.on("data", (chunk) => chunks.push(chunk));
+        let downloadedBytes = 0;
+        res.on("data", (chunk) => {
+          downloadedBytes += chunk.length;
+          if (downloadedBytes > maxBytes) {
+            res.destroy();
+            reject(new Error(`Download exceeds ${maxBytes} bytes`));
+            return;
+          }
+          chunks.push(chunk);
+        });
         res.on("end", () => resolve(Buffer.concat(chunks)));
         res.on("error", reject);
       })
@@ -45,25 +65,102 @@ function download(url) {
   });
 }
 
-function extractArchive(buffer, archiveType, destDir) {
-  const tmpFile = path.join(os.tmpdir(), `hooklistener-${Date.now()}.${archiveType}`);
-  fs.writeFileSync(tmpFile, buffer);
+function parseChecksumManifest(manifest, archiveName) {
+  const matches = [];
+
+  for (const line of manifest.toString("utf8").split(/\r?\n/)) {
+    const fields = line.trim().split(/\s+/);
+    if (fields.length < 2) {
+      continue;
+    }
+
+    const listedName = fields[1].replace(/^\*/, "");
+    if (listedName !== archiveName) {
+      continue;
+    }
+
+    if (fields.length !== 2 || !/^[a-fA-F0-9]{64}$/.test(fields[0])) {
+      throw new Error(`Malformed checksum entry for ${archiveName}`);
+    }
+
+    matches.push(fields[0].toLowerCase());
+  }
+
+  if (matches.length === 0) {
+    throw new Error(`Checksum manifest is missing an entry for ${archiveName}`);
+  }
+  if (matches.length !== 1) {
+    throw new Error(`Checksum manifest has duplicate entries for ${archiveName}`);
+  }
+
+  return matches[0];
+}
+
+function verifyChecksum(buffer, expectedChecksum) {
+  if (!/^[a-f0-9]{64}$/.test(expectedChecksum)) {
+    throw new Error("Expected checksum is not a valid SHA-256 digest");
+  }
+
+  const actualChecksum = crypto.createHash("sha256").update(buffer).digest("hex");
+  if (actualChecksum !== expectedChecksum) {
+    throw new Error(
+      `Checksum verification failed: expected ${expectedChecksum}, got ${actualChecksum}`
+    );
+  }
+}
+
+function writeExclusivePrivateFile(filePath, contents) {
+  fs.writeFileSync(filePath, contents, { flag: "wx", mode: 0o600 });
+}
+
+function extractArchive(buffer, archiveType, destDir, options = {}) {
+  if (archiveType !== "zip" && archiveType !== "tar.gz") {
+    throw new Error(`Unsupported archive type: ${archiveType}`);
+  }
+
+  const platform = options.platform ?? process.platform;
+  const temporaryRoot = options.temporaryRoot ?? os.tmpdir();
+  const runCommand = options.execFileSync ?? execFileSync;
+  const temporaryDirectory = fs.mkdtempSync(
+    path.join(temporaryRoot, "hooklistener-install-")
+  );
+
   try {
     fs.mkdirSync(destDir, { recursive: true });
+    const archivePath = path.join(temporaryDirectory, `archive.${archiveType}`);
+    writeExclusivePrivateFile(archivePath, buffer);
+
     if (archiveType === "zip") {
-      if (process.platform === "win32") {
-        execSync(
-          `powershell -Command "Expand-Archive -Path '${tmpFile}' -DestinationPath '${destDir}' -Force"`,
-          { stdio: "pipe" }
+      if (platform === "win32") {
+        const scriptPath = path.join(temporaryDirectory, "expand-archive.ps1");
+        writeExclusivePrivateFile(scriptPath, POWERSHELL_EXPAND_ARCHIVE_SCRIPT);
+        runCommand(
+          "powershell.exe",
+          [
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            scriptPath,
+            archivePath,
+            destDir,
+          ],
+          { stdio: "pipe", windowsHide: true }
         );
       } else {
-        execSync(`unzip -o "${tmpFile}" -d "${destDir}"`, { stdio: "pipe" });
+        runCommand("unzip", ["-o", archivePath, "-d", destDir], {
+          stdio: "pipe",
+        });
       }
     } else {
-      execSync(`tar -xzf "${tmpFile}" -C "${destDir}"`, { stdio: "pipe" });
+      runCommand("tar", ["-xzf", archivePath, "-C", destDir], {
+        stdio: "pipe",
+      });
     }
   } finally {
-    fs.unlinkSync(tmpFile);
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
   }
 }
 
@@ -95,13 +192,20 @@ async function main() {
   }
 
   const version = getPackageVersion();
-  const archiveName = `hooklistener-${platform.target}.${platform.archive}`;
+  const archiveName = `${BIN_NAME}-${platform.target}.${platform.archive}`;
   const url = `https://github.com/${REPO}/releases/download/v${version}/${archiveName}`;
+  const checksumsUrl = `https://github.com/${REPO}/releases/download/v${version}/SHA256SUMS.txt`;
 
   console.log(`Downloading hooklistener v${version} for ${platformKey}...`);
 
   try {
+    const checksumManifest = await download(
+      checksumsUrl,
+      CHECKSUM_MANIFEST_MAX_BYTES
+    );
+    const expectedChecksum = parseChecksumManifest(checksumManifest, archiveName);
     const buffer = await download(url);
+    verifyChecksum(buffer, expectedChecksum);
     extractArchive(buffer, platform.archive, BIN_DIR);
 
     if (!fs.existsSync(BIN_PATH)) {
@@ -112,7 +216,7 @@ async function main() {
     markExecutable(BIN_PATH);
     console.log(`hooklistener v${version} installed successfully.`);
   } catch (err) {
-    console.error(`Failed to download hooklistener v${version}: ${err.message}`);
+    console.error(`Failed to install hooklistener v${version}: ${err.message}`);
     console.error(
       `\nYou can manually install the binary and set HOOKLISTENER_BINARY_PATH to its location.`
     );
@@ -120,4 +224,8 @@ async function main() {
   }
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = { extractArchive, parseChecksumManifest, verifyChecksum };

--- a/npm/packages/hooklistener/scripts/install.test.js
+++ b/npm/packages/hooklistener/scripts/install.test.js
@@ -1,0 +1,160 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  extractArchive,
+  parseChecksumManifest,
+  verifyChecksum,
+} = require("./install");
+
+const ARCHIVE = "hooklistener-x86_64-unknown-linux-gnu.tar.gz";
+const DIGEST = "a".repeat(64);
+
+function withExtractionFixture(callback) {
+  const fixtureRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), "hooklistener-install-test-")
+  );
+  const temporaryRoot = path.join(fixtureRoot, "temporary");
+  const destination = path.join(fixtureRoot, "destination");
+  fs.mkdirSync(temporaryRoot);
+
+  try {
+    callback({ destination, fixtureRoot, temporaryRoot });
+  } finally {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+}
+
+test("parseChecksumManifest returns the exact archive checksum", () => {
+  const manifest = [
+    `${"b".repeat(64)}  ${ARCHIVE}.sig`,
+    `${DIGEST}  ${ARCHIVE}`,
+  ].join("\n");
+
+  assert.equal(parseChecksumManifest(Buffer.from(manifest), ARCHIVE), DIGEST);
+});
+
+test("parseChecksumManifest rejects a missing archive entry", () => {
+  const manifest = `${DIGEST}  another-archive.tar.gz\n`;
+
+  assert.throws(
+    () => parseChecksumManifest(Buffer.from(manifest), ARCHIVE),
+    /missing an entry/
+  );
+});
+
+test("parseChecksumManifest rejects malformed digests", () => {
+  const manifest = `not-a-sha256  ${ARCHIVE}\n`;
+
+  assert.throws(
+    () => parseChecksumManifest(Buffer.from(manifest), ARCHIVE),
+    /Malformed checksum entry/
+  );
+});
+
+test("parseChecksumManifest rejects duplicate archive entries", () => {
+  const manifest = `${DIGEST}  ${ARCHIVE}\n${DIGEST}  ${ARCHIVE}\n`;
+
+  assert.throws(
+    () => parseChecksumManifest(Buffer.from(manifest), ARCHIVE),
+    /duplicate entries/
+  );
+});
+
+test("verifyChecksum accepts the matching SHA-256 digest", () => {
+  const payload = Buffer.from("hooklistener");
+  const digest = "f09e19981034811c388de0bf5af209172448fd891cda83c9a3c5dda3a703d0ca";
+
+  assert.doesNotThrow(() => verifyChecksum(payload, digest));
+});
+
+test("verifyChecksum rejects a mismatched SHA-256 digest", () => {
+  assert.throws(
+    () => verifyChecksum(Buffer.from("hooklistener"), "0".repeat(64)),
+    /Checksum verification failed/
+  );
+});
+
+test("extractArchive uses a private workspace and tar argument array", () => {
+  withExtractionFixture(({ destination, temporaryRoot }) => {
+    let invocation;
+
+    extractArchive(Buffer.from("archive contents"), "tar.gz", destination, {
+      platform: "linux",
+      temporaryRoot,
+      execFileSync(command, args, options) {
+        invocation = { args, command, options };
+        const archivePath = args[1];
+        const workspace = path.dirname(archivePath);
+
+        if (process.platform !== "win32") {
+          assert.equal(fs.statSync(workspace).mode & 0o777, 0o700);
+          assert.equal(fs.statSync(archivePath).mode & 0o777, 0o600);
+        }
+        assert.equal(fs.readFileSync(archivePath, "utf8"), "archive contents");
+      },
+    });
+
+    assert.equal(invocation.command, "tar");
+    assert.deepEqual(invocation.args.slice(0, 1), ["-xzf"]);
+    assert.deepEqual(invocation.args.slice(2), ["-C", destination]);
+    assert.deepEqual(invocation.options, { stdio: "pipe" });
+    assert.deepEqual(fs.readdirSync(temporaryRoot), []);
+  });
+});
+
+test("extractArchive passes Windows paths as positional PowerShell arguments", () => {
+  withExtractionFixture(({ fixtureRoot, temporaryRoot }) => {
+    const destination = path.join(
+      fixtureRoot,
+      "destination with spaces; $(not-a-command) 'quoted'"
+    );
+    let invocation;
+    let scriptContents;
+
+    extractArchive(Buffer.from("zip contents"), "zip", destination, {
+      platform: "win32",
+      temporaryRoot,
+      execFileSync(command, args, options) {
+        const fileFlagIndex = args.indexOf("-File");
+        const scriptPath = args[fileFlagIndex + 1];
+        invocation = { args, command, fileFlagIndex, options };
+        scriptContents = fs.readFileSync(scriptPath, "utf8");
+      },
+    });
+
+    const scriptPath = invocation.args[invocation.fileFlagIndex + 1];
+    const archivePath = invocation.args[invocation.fileFlagIndex + 2];
+    assert.equal(invocation.command, "powershell.exe");
+    assert.equal(invocation.args.includes("-Command"), false);
+    assert.equal(invocation.args[invocation.fileFlagIndex + 3], destination);
+    assert.equal(path.dirname(scriptPath), path.dirname(archivePath));
+    assert.match(scriptContents, /Position=0/);
+    assert.match(scriptContents, /Position=1/);
+    assert.equal(scriptContents.includes(destination), false);
+    assert.deepEqual(invocation.options, { stdio: "pipe", windowsHide: true });
+    assert.deepEqual(fs.readdirSync(temporaryRoot), []);
+  });
+});
+
+test("extractArchive removes its private workspace when extraction fails", () => {
+  withExtractionFixture(({ destination, temporaryRoot }) => {
+    assert.throws(
+      () =>
+        extractArchive(Buffer.from("archive contents"), "tar.gz", destination, {
+          platform: "linux",
+          temporaryRoot,
+          execFileSync() {
+            throw new Error("extractor failed");
+          },
+        }),
+      /extractor failed/
+    );
+    assert.deepEqual(fs.readdirSync(temporaryRoot), []);
+  });
+});

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -49,13 +49,33 @@ function Get-ExpectedChecksum {
         [string]$ArchiveName
     )
 
-    $Content = Get-Content $ChecksumsPath
-    foreach ($Line in $Content) {
-        if ($Line -match "^([a-fA-F0-9]{64})\s+.*$([regex]::Escape($ArchiveName))$") {
-            return $Matches[1]
+    $Entries = @()
+    foreach ($Line in Get-Content $ChecksumsPath) {
+        if ($Line -notmatch '^(\S+)[ \t]+(\*?)(\S+)[ \t]*$') {
+            continue
         }
+
+        $Checksum = $Matches[1]
+        $ListedName = $Matches[3]
+        if ($ListedName -cne $ArchiveName) {
+            continue
+        }
+
+        if ($Checksum -cnotmatch '^[a-fA-F0-9]{64}$') {
+            throw "Checksum manifest contains an invalid SHA256 digest for $ArchiveName"
+        }
+
+        $Entries += $Checksum.ToLowerInvariant()
     }
-    return $null
+
+    if ($Entries.Count -eq 0) {
+        throw "Checksum manifest is missing an entry for $ArchiveName"
+    }
+    if ($Entries.Count -ne 1) {
+        throw "Checksum manifest has duplicate entries for $ArchiveName"
+    }
+
+    return $Entries[0]
 }
 
 function Verify-Checksum {
@@ -64,11 +84,14 @@ function Verify-Checksum {
         [string]$ExpectedChecksum
     )
 
-    $ActualChecksum = (Get-FileHash -Path $FilePath -Algorithm SHA256).Hash.ToLower()
-    $ExpectedLower = $ExpectedChecksum.ToLower()
+    if ($ExpectedChecksum -cnotmatch '^[a-f0-9]{64}$') {
+        throw "Expected checksum is not a valid SHA256 digest"
+    }
 
-    if ($ActualChecksum -ne $ExpectedLower) {
-        Write-Error-Custom "Checksum verification failed!`nExpected: $ExpectedLower`nActual: $ActualChecksum"
+    $ActualChecksum = (Get-FileHash -Path $FilePath -Algorithm SHA256).Hash.ToLowerInvariant()
+
+    if ($ActualChecksum -cne $ExpectedChecksum) {
+        Write-Error-Custom "Checksum verification failed!`nExpected: $ExpectedChecksum`nActual: $ActualChecksum"
     }
 
     Write-Success "Checksum verified"
@@ -127,11 +150,7 @@ function Install-HooklistenerCli {
         # Verify checksum
         Write-Info "Verifying checksum..."
         $ExpectedChecksum = Get-ExpectedChecksum -ChecksumsPath $ChecksumsPath -ArchiveName $ArchiveName
-        if ($ExpectedChecksum) {
-            Verify-Checksum -FilePath $ArchivePath -ExpectedChecksum $ExpectedChecksum
-        } else {
-            Write-Warn "Could not find checksum for $ArchiveName, skipping verification"
-        }
+        Verify-Checksum -FilePath $ArchivePath -ExpectedChecksum $ExpectedChecksum
 
         # Extract archive
         Write-Info "Extracting archive..."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -129,27 +129,99 @@ verify_checksum() {
     CHECKSUMS="$2"
     ARCHIVE_NAME="$3"
 
-    EXPECTED=$(grep "$ARCHIVE_NAME" "$CHECKSUMS" | awk '{print $1}')
+    EXPECTED=$(awk -v archive_name="$ARCHIVE_NAME" '
+        {
+            listed_name = $2
+            sub(/^\*/, "", listed_name)
+            if (listed_name == archive_name) {
+                matches++
+                checksum = $1
+                if (NF != 2) {
+                    malformed = 1
+                }
+            }
+        }
+        END {
+            if (matches != 1 || malformed) {
+                exit 1
+            }
+            print checksum
+        }
+    ' "$CHECKSUMS") || error "Checksum manifest must contain exactly one entry for $ARCHIVE_NAME"
 
-    if [ -z "$EXPECTED" ]; then
-        warn "Could not find checksum for $ARCHIVE_NAME, skipping verification"
-        return 0
+    if [ "${#EXPECTED}" -ne 64 ]; then
+        error "Checksum manifest contains an invalid SHA256 digest for $ARCHIVE_NAME"
     fi
+    case "$EXPECTED" in
+        *[!0-9a-fA-F]*)
+            error "Checksum manifest contains an invalid SHA256 digest for $ARCHIVE_NAME"
+            ;;
+    esac
+    EXPECTED=$(printf '%s' "$EXPECTED" | tr '[:upper:]' '[:lower:]')
 
     if command -v sha256sum >/dev/null 2>&1; then
         ACTUAL=$(sha256sum "$ARCHIVE" | awk '{print $1}')
     elif command -v shasum >/dev/null 2>&1; then
         ACTUAL=$(shasum -a 256 "$ARCHIVE" | awk '{print $1}')
     else
-        warn "No SHA256 tool found, skipping checksum verification"
-        return 0
+        error "A SHA256 checksum tool (sha256sum or shasum) is required"
     fi
+    ACTUAL=$(printf '%s' "$ACTUAL" | tr '[:upper:]' '[:lower:]')
 
     if [ "$EXPECTED" != "$ACTUAL" ]; then
         error "Checksum verification failed!\nExpected: $EXPECTED\nActual: $ACTUAL"
     fi
 
+    VERIFIED_ARCHIVE_SHA256="$EXPECTED"
     success "Checksum verified"
+}
+
+# When privilege elevation is required, pass the archive through an already-open
+# descriptor and verify those exact bytes again in a root-owned temporary
+# directory. This prevents an unprivileged process from swapping the extracted
+# binary between checksum verification and the privileged install.
+install_verified_archive_as_root() {
+    ARCHIVE="$1"
+    DESTINATION="$2"
+    EXPECTED="$3"
+
+    sudo sh -c '
+        set -eu
+        umask 077
+        destination=$1
+        expected=$2
+        root_tmp=$(mktemp -d /tmp/hooklistener-install.XXXXXX)
+        trap '\''rm -rf "$root_tmp"'\'' EXIT HUP INT TERM
+
+        archive="$root_tmp/release.tar.gz"
+        binary="$root_tmp/hooklistener"
+        cat <&3 > "$archive"
+
+        if command -v sha256sum >/dev/null 2>&1; then
+            actual=$(sha256sum "$archive" | awk '\''{print $1}'\'')
+        elif command -v shasum >/dev/null 2>&1; then
+            actual=$(shasum -a 256 "$archive" | awk '\''{print $1}'\'')
+        else
+            echo "error: a SHA256 checksum tool is required after privilege elevation" >&2
+            exit 1
+        fi
+
+        if [ "$actual" != "$expected" ]; then
+            echo "error: release archive changed after checksum verification" >&2
+            exit 1
+        fi
+
+        member_count=$(tar -tzf "$archive" | awk '\''$0 == "hooklistener" { count++ } END { print count + 0 }'\'')
+        if [ "$member_count" -ne 1 ]; then
+            echo "error: release archive must contain exactly one root-level hooklistener binary" >&2
+            exit 1
+        fi
+
+        tar -xOzf "$archive" hooklistener > "$binary"
+        chmod 0755 "$binary"
+        mkdir -p "$(dirname "$destination")"
+        mv -f "$binary" "$destination"
+    ' sh "$DESTINATION" "$EXPECTED" 3< "$ARCHIVE"
 }
 
 # Main installation function
@@ -184,9 +256,6 @@ main() {
     info "Verifying checksum..."
     verify_checksum "$ARCHIVE_PATH" "$CHECKSUMS_PATH" "$ARCHIVE_NAME"
 
-    info "Extracting archive..."
-    tar -xzf "$ARCHIVE_PATH" -C "$TMP_DIR"
-
     # Check if we need sudo
     NEED_SUDO=""
     if [ ! -w "$INSTALL_DIR" ]; then
@@ -200,12 +269,19 @@ main() {
         info "Installing to $INSTALL_DIR..."
     fi
 
-    # Create install directory if it doesn't exist
-    $NEED_SUDO mkdir -p "$INSTALL_DIR"
-
-    # Install the binary with the expected command name
-    $NEED_SUDO cp "${TMP_DIR}/hooklistener" "${INSTALL_DIR}/${BINARY_NAME}"
-    $NEED_SUDO chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
+    if [ -n "$NEED_SUDO" ]; then
+        info "Re-verifying and extracting archive in a privileged temporary directory..."
+        install_verified_archive_as_root \
+            "$ARCHIVE_PATH" \
+            "${INSTALL_DIR}/${BINARY_NAME}" \
+            "$VERIFIED_ARCHIVE_SHA256"
+    else
+        info "Extracting archive..."
+        tar -xzf "$ARCHIVE_PATH" -C "$TMP_DIR"
+        mkdir -p "$INSTALL_DIR"
+        cp "${TMP_DIR}/hooklistener" "${INSTALL_DIR}/${BINARY_NAME}"
+        chmod 0755 "${INSTALL_DIR}/${BINARY_NAME}"
+    fi
 
     # Verify installation
     if [ -x "${INSTALL_DIR}/${BINARY_NAME}" ]; then

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,21 +1,261 @@
 use crate::{
     errors::TunnelLifecycleError,
     models::{ForwardResponse, WebhookRequest},
+    target_policy::TargetPolicy,
 };
 use anyhow::{Context, Result, anyhow};
 use reqwest::{
-    Client, Response, Url,
+    Client, Response, StatusCode, Url,
     header::{AUTHORIZATION, HeaderMap, HeaderValue},
 };
 use serde::{Deserialize, Deserializer, Serialize, de::DeserializeOwned};
 use serde_json::Value;
 use std::collections::HashMap;
+use std::net::IpAddr;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 const RELAY_TICKET_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 const TOKEN_REFRESH_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 const API_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const API_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+const REPLAY_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_REPLAY_RESPONSE_BODY_BYTES: usize = 1024 * 1024;
+const MAX_SERVER_ERROR_DETAIL_BYTES: usize = 256;
+pub(crate) const ALLOW_INSECURE_DEV_SERVER_ENV: &str = "HOOKLISTENER_ALLOW_INSECURE_DEV_SERVER";
+
+static ALLOW_INSECURE_DEV_SERVER: AtomicBool = AtomicBool::new(false);
+static INSECURE_DEV_SERVER_WARNING_EMITTED: AtomicBool = AtomicBool::new(false);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ServerUrlKind {
+    Api,
+    WebSocket,
+    Relay,
+}
+
+impl ServerUrlKind {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Api => "API",
+            Self::WebSocket => "WebSocket",
+            Self::Relay => "relay",
+        }
+    }
+
+    fn supported_schemes(self) -> &'static str {
+        match self {
+            Self::Api => "https",
+            Self::WebSocket => "wss",
+            Self::Relay => "https or wss",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ServerUrlSecurity {
+    Tls,
+    LoopbackCleartext,
+    ExplicitDevCleartext,
+}
+
+pub(crate) fn configure_server_url_security(allow_insecure_dev_server: bool) {
+    let env_opt_in = std::env::var(ALLOW_INSECURE_DEV_SERVER_ENV)
+        .ok()
+        .is_some_and(|value| matches!(value.trim(), "1" | "true" | "TRUE" | "yes" | "YES"));
+    ALLOW_INSECURE_DEV_SERVER.store(allow_insecure_dev_server || env_opt_in, Ordering::Relaxed);
+}
+
+fn server_url_is_loopback(url: &Url) -> bool {
+    let Some(host) = url.host_str() else {
+        return false;
+    };
+    let host = host.trim_matches(['[', ']']).trim_end_matches('.');
+
+    host.eq_ignore_ascii_case("localhost")
+        || host
+            .parse::<IpAddr>()
+            .is_ok_and(|address| address.is_loopback())
+}
+
+pub(crate) fn validate_server_url(
+    value: &str,
+    kind: ServerUrlKind,
+    allow_insecure_dev_server: bool,
+) -> Result<ServerUrlSecurity> {
+    let url = Url::parse(value).map_err(|_| {
+        anyhow!(
+            "Invalid Hooklistener {} URL. Use {}.",
+            kind.label(),
+            kind.supported_schemes()
+        )
+    })?;
+    if url.host_str().is_none() {
+        return Err(anyhow!(
+            "Invalid Hooklistener {} URL: a host is required.",
+            kind.label()
+        ));
+    }
+
+    match (kind, url.scheme()) {
+        (ServerUrlKind::Api, "https")
+        | (ServerUrlKind::WebSocket, "wss")
+        | (ServerUrlKind::Relay, "https" | "wss") => return Ok(ServerUrlSecurity::Tls),
+        (ServerUrlKind::Api, "http")
+        | (ServerUrlKind::WebSocket, "ws")
+        | (ServerUrlKind::Relay, "http" | "ws") => {}
+        (_, scheme) => {
+            return Err(anyhow!(
+                "Unsupported Hooklistener {} URL scheme '{}'. Use {}.",
+                kind.label(),
+                scheme,
+                kind.supported_schemes()
+            ));
+        }
+    }
+
+    if server_url_is_loopback(&url) {
+        return Ok(ServerUrlSecurity::LoopbackCleartext);
+    }
+    if allow_insecure_dev_server {
+        return Ok(ServerUrlSecurity::ExplicitDevCleartext);
+    }
+
+    Err(anyhow!(
+        "Cleartext Hooklistener {} URLs are blocked for non-loopback hosts. Use {}, or opt in for isolated development with --allow-insecure-dev-server or {}=1.",
+        kind.label(),
+        kind.supported_schemes(),
+        ALLOW_INSECURE_DEV_SERVER_ENV
+    ))
+}
+
+fn validate_configured_server_url(value: &str, kind: ServerUrlKind) -> Result<()> {
+    let security = validate_server_url(
+        value,
+        kind,
+        ALLOW_INSECURE_DEV_SERVER.load(Ordering::Relaxed),
+    )?;
+    if security == ServerUrlSecurity::ExplicitDevCleartext
+        && !INSECURE_DEV_SERVER_WARNING_EMITTED.swap(true, Ordering::Relaxed)
+    {
+        eprintln!(
+            "WARNING: cleartext Hooklistener {} transport is enabled for development; credentials and relay tickets can be intercepted.",
+            kind.label()
+        );
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_api_base_url(value: &str) -> Result<()> {
+    validate_configured_server_url(value, ServerUrlKind::Api)
+}
+
+pub(crate) fn validate_websocket_base_url(value: &str) -> Result<()> {
+    validate_configured_server_url(value, ServerUrlKind::WebSocket)
+}
+
+pub(crate) fn validate_relay_base_url(value: &str) -> Result<()> {
+    validate_configured_server_url(value, ServerUrlKind::Relay)
+}
+
+fn relay_http_base_url(value: &str) -> Result<String> {
+    validate_relay_base_url(value)?;
+    let mut url = Url::parse(value).context("Invalid Hooklistener relay URL")?;
+    let http_scheme = match url.scheme() {
+        "wss" => "https",
+        "ws" => "http",
+        "https" => "https",
+        "http" => "http",
+        _ => return Err(anyhow!("Unsupported Hooklistener relay URL scheme")),
+    };
+    url.set_scheme(http_scheme)
+        .map_err(|_| anyhow!("Failed to normalize Hooklistener relay URL"))?;
+    Ok(url.to_string())
+}
+
+fn bounded_control_neutral_text(value: &str) -> String {
+    let mut output = String::with_capacity(value.len().min(MAX_SERVER_ERROR_DETAIL_BYTES));
+    let mut truncated = false;
+
+    for character in value.chars() {
+        let rendered = if character.is_control() {
+            character.escape_default().collect::<String>()
+        } else {
+            character.to_string()
+        };
+        if output.len().saturating_add(rendered.len()) > MAX_SERVER_ERROR_DETAIL_BYTES - 3 {
+            truncated = true;
+            break;
+        }
+        output.push_str(&rendered);
+    }
+    if truncated {
+        output.push_str("...");
+    }
+    output
+}
+
+fn structured_server_error_detail(body: &str) -> Option<String> {
+    let payload = serde_json::from_str::<Value>(body).ok()?;
+    let error = payload.get("error").unwrap_or(&payload);
+    let code = error
+        .get("code")
+        .and_then(Value::as_str)
+        .or_else(|| payload.get("code").and_then(Value::as_str));
+    let message = error
+        .get("message")
+        .and_then(Value::as_str)
+        .or_else(|| error.as_str())
+        .or_else(|| payload.get("message").and_then(Value::as_str));
+
+    let detail = match (code, message) {
+        (Some(code), Some(message)) => format!("code={code}; message={message}"),
+        (Some(code), None) => format!("code={code}"),
+        (None, Some(message)) => format!("message={message}"),
+        (None, None) => return None,
+    };
+    Some(bounded_control_neutral_text(&detail))
+}
+
+fn server_response_error(context: &str, status: StatusCode, body: &str) -> anyhow::Error {
+    match structured_server_error_detail(body) {
+        Some(detail) => anyhow!("{context} (HTTP {status}; {detail})"),
+        None => anyhow!("{context} (HTTP {status})"),
+    }
+}
+
+async fn read_replay_response_body(response: &mut Response) -> Result<Vec<u8>> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > MAX_REPLAY_RESPONSE_BODY_BYTES as u64)
+    {
+        return Err(anyhow!(
+            "Replay response body exceeded {MAX_REPLAY_RESPONSE_BODY_BYTES} bytes"
+        ));
+    }
+
+    let initial_capacity = response
+        .content_length()
+        .and_then(|length| usize::try_from(length).ok())
+        .unwrap_or(0)
+        .min(MAX_REPLAY_RESPONSE_BODY_BYTES);
+    let mut body = Vec::with_capacity(initial_capacity);
+    while let Some(chunk) = response.chunk().await.map_err(|error| {
+        anyhow!(
+            "Failed to read replay response: {}",
+            bounded_control_neutral_text(&error.without_url().to_string())
+        )
+    })? {
+        if chunk.len() > MAX_REPLAY_RESPONSE_BODY_BYTES.saturating_sub(body.len()) {
+            return Err(anyhow!(
+                "Replay response body exceeded {MAX_REPLAY_RESPONSE_BODY_BYTES} bytes"
+            ));
+        }
+        body.extend_from_slice(&chunk);
+    }
+
+    Ok(body)
+}
 
 fn deserialize_map_or_default<'de, D>(
     deserializer: D,
@@ -676,9 +916,11 @@ pub struct ApiClient {
     base_url: Option<String>,
 }
 
-pub fn default_base_url() -> String {
-    std::env::var("HOOKLISTENER_API_URL")
-        .unwrap_or_else(|_| "https://app.hooklistener.com".to_string())
+pub fn default_base_url() -> Result<String> {
+    let base_url = std::env::var("HOOKLISTENER_API_URL")
+        .unwrap_or_else(|_| "https://app.hooklistener.com".to_string());
+    validate_api_base_url(&base_url)?;
+    Ok(base_url)
 }
 
 /// Refresh an expired CLI access token using a refresh token (no auth needed).
@@ -686,6 +928,7 @@ pub async fn refresh_access_token(
     refresh_token: &str,
     base_url: &str,
 ) -> Result<TokenRefreshResponse> {
+    validate_api_base_url(base_url)?;
     let url = format!("{}/api/v1/auth/refresh", base_url.trim_end_matches('/'));
     let body = serde_json::json!({ "refresh_token": refresh_token });
 
@@ -701,7 +944,7 @@ pub async fn refresh_access_token(
     let status = response.status();
     let text = response.text().await.unwrap_or_default();
     if !status.is_success() {
-        return Err(anyhow!("Token refresh failed (HTTP {}): {}", status, text));
+        return Err(server_response_error("Token refresh failed", status, &text));
     }
 
     serde_json::from_str(&text).context("Failed to parse refresh response")
@@ -709,7 +952,7 @@ pub async fn refresh_access_token(
 
 /// Revoke a CLI refresh token server-side (best-effort, no auth needed).
 pub async fn revoke_refresh_token(refresh_token: &str) -> Result<()> {
-    let base_url = default_base_url();
+    let base_url = default_base_url()?;
     let url = format!("{}/api/v1/auth/revoke", base_url.trim_end_matches('/'));
     let body = serde_json::json!({ "refresh_token": refresh_token });
 
@@ -724,9 +967,7 @@ pub async fn issue_relay_ticket(
     base_url: &str,
     plan: &Value,
 ) -> Result<RelayTicket> {
-    let http_base = base_url
-        .replacen("wss://", "https://", 1)
-        .replacen("ws://", "http://", 1);
+    let http_base = relay_http_base_url(base_url)?;
     let url = format!(
         "{}/api/v1/tunnel/relay-tickets",
         http_base.trim_end_matches('/')
@@ -751,7 +992,7 @@ pub async fn issue_relay_ticket(
         } else {
             "Relay handshake ticket request failed"
         };
-        return Err(anyhow!("{} (HTTP {}): {}", failure, status, text));
+        return Err(server_response_error(failure, status, &text));
     }
 
     serde_json::from_str::<RelayTicketEnvelope>(&text)
@@ -760,26 +1001,29 @@ pub async fn issue_relay_ticket(
 }
 
 impl ApiClient {
-    pub fn for_forwarding() -> Self {
-        Self {
-            client: Client::new(),
+    pub fn for_forwarding() -> Result<Self> {
+        let client = Client::builder()
+            .timeout(REPLAY_REQUEST_TIMEOUT)
+            .redirect(reqwest::redirect::Policy::none())
+            .no_proxy()
+            .build()
+            .context("Failed to build replay client")?;
+        Ok(Self {
+            client,
             base_url: None,
-        }
+        })
     }
 
     /// Create a client with no authentication (for anonymous endpoints).
     pub fn unauthenticated() -> Result<Self> {
-        Self::unauthenticated_at(default_base_url())
+        Self::unauthenticated_at(default_base_url()?)
     }
 
     pub fn unauthenticated_at(base_url: String) -> Result<Self> {
+        let base_url = relay_http_base_url(&base_url)?;
         Ok(Self {
             client: Client::new(),
-            base_url: Some(
-                base_url
-                    .replacen("wss://", "https://", 1)
-                    .replacen("ws://", "http://", 1),
-            ),
+            base_url: Some(base_url),
         })
     }
 
@@ -787,7 +1031,7 @@ impl ApiClient {
         access_token: String,
         organization_id: Option<String>,
     ) -> Result<Self> {
-        Self::with_base_url(access_token, default_base_url(), organization_id)
+        Self::with_base_url(access_token, default_base_url()?, organization_id)
     }
 
     pub fn with_base_url(
@@ -795,6 +1039,7 @@ impl ApiClient {
         base_url: String,
         organization_id: Option<String>,
     ) -> Result<Self> {
+        validate_api_base_url(&base_url)?;
         let mut headers = HeaderMap::new();
         let auth = format!("Bearer {}", access_token);
         headers.insert(
@@ -850,7 +1095,11 @@ impl ApiClient {
         let status = response.status();
         let text = response.text().await.unwrap_or_default();
         if !status.is_success() {
-            return Err(anyhow!("{} failed (HTTP {}): {}", context, status, text));
+            return Err(server_response_error(
+                &format!("{context} failed"),
+                status,
+                &text,
+            ));
         }
 
         serde_json::from_str(&text).with_context(|| format!("Failed to parse {} response", context))
@@ -878,6 +1127,8 @@ impl ApiClient {
             .get("message")
             .and_then(Value::as_str)
             .unwrap_or(context);
+        let code = bounded_control_neutral_text(code);
+        let message = bounded_control_neutral_text(message);
 
         if code == "cursor_expired" {
             return Err(TunnelLifecycleError::CursorExpired {
@@ -892,8 +1143,8 @@ impl ApiClient {
 
         Err(TunnelLifecycleError::Api {
             status: status.as_u16(),
-            code: code.to_string(),
-            message: message.to_string(),
+            code,
+            message,
         }
         .into())
     }
@@ -1009,7 +1260,11 @@ impl ApiClient {
         }
 
         let text = response.text().await.unwrap_or_default();
-        Err(anyhow!("{} failed (HTTP {}): {}", context, status, text))
+        Err(server_response_error(
+            &format!("{context} failed"),
+            status,
+            &text,
+        ))
     }
 
     pub async fn list_organizations(&self) -> Result<Vec<Organization>> {
@@ -1502,6 +1757,8 @@ impl ApiClient {
         target_url: &str,
     ) -> Result<ForwardResponse> {
         let start_time = Instant::now();
+        let target = TargetPolicy::resolve(target_url, false, false).await?;
+        let replay_client = target.http_client_with_timeout(REPLAY_REQUEST_TIMEOUT)?;
 
         // Build the forwarding request
         let method = match original_request.method.as_str() {
@@ -1515,15 +1772,15 @@ impl ApiClient {
             _ => reqwest::Method::GET,
         };
 
-        // Build URL with query parameters
-        let mut url = target_url.parse::<Url>()?;
+        // Keep the caller's target path while adding the captured request's query.
+        let mut url = target.request_url("", None)?;
         if !original_request.query_params.is_empty() {
             for (key, value) in &original_request.query_params {
                 url.query_pairs_mut().append_pair(key, &value.to_string());
             }
         }
 
-        let mut request_builder = self.client.request(method, url);
+        let mut request_builder = replay_client.request(method, url);
 
         // Add headers (excluding host-related ones)
         for (key, value) in &original_request.headers {
@@ -1553,7 +1810,7 @@ impl ApiClient {
 
         // Execute the request
         match request_builder.send().await {
-            Ok(response) => {
+            Ok(mut response) => {
                 let status_code = response.status().as_u16();
 
                 // Extract response headers
@@ -1566,11 +1823,11 @@ impl ApiClient {
 
                 // Decode a bounded, content-aware preview for display. The tunnel path
                 // separately preserves original response bytes for the public caller.
-                let body = match response.bytes().await {
+                let body = match read_replay_response_body(&mut response).await {
                     Ok(bytes) => {
                         crate::tunnel::body_preview(&bytes, &response_headers).unwrap_or_default()
                     }
-                    Err(_) => "(Failed to read response body)".to_string(),
+                    Err(error) => format!("({error})"),
                 };
 
                 let duration = start_time.elapsed();
@@ -1585,7 +1842,7 @@ impl ApiClient {
                     duration_ms: duration.as_millis() as u64,
                 })
             }
-            Err(e) => {
+            Err(error) => {
                 let duration = start_time.elapsed();
 
                 Ok(ForwardResponse {
@@ -1593,7 +1850,9 @@ impl ApiClient {
                     status_code: None,
                     headers: HashMap::new(),
                     body: String::new(),
-                    error_message: Some(e.to_string()),
+                    error_message: Some(bounded_control_neutral_text(
+                        &error.without_url().to_string(),
+                    )),
                     target_url: target_url.to_string(),
                     duration_ms: duration.as_millis() as u64,
                 })
@@ -1607,6 +1866,144 @@ mod tests {
     use super::*;
     use flate2::{Compression, write::GzEncoder};
     use std::io::Write;
+
+    fn replay_test_request(method: &str) -> WebhookRequest {
+        WebhookRequest {
+            id: "req-replay".to_string(),
+            timestamp: 0,
+            remote_addr: "127.0.0.1".to_string(),
+            headers: HashMap::new(),
+            content_length: 0,
+            method: method.to_string(),
+            url: "/webhook".to_string(),
+            path: Some("/webhook".to_string()),
+            query_params: HashMap::new(),
+            created_at: "2024-01-01".to_string(),
+            body_preview: None,
+            body: None,
+        }
+    }
+
+    #[test]
+    fn server_url_validation_accepts_tls_api_and_websocket_urls() {
+        let urls = [
+            ("https://app.hooklistener.com", ServerUrlKind::Api),
+            ("wss://api.hooklistener.com", ServerUrlKind::WebSocket),
+        ];
+
+        assert!(urls.into_iter().all(|(url, kind)| matches!(
+            validate_server_url(url, kind, false),
+            Ok(ServerUrlSecurity::Tls)
+        )));
+    }
+
+    #[test]
+    fn server_url_validation_accepts_loopback_cleartext_without_opt_in() {
+        let urls = [
+            ("http://localhost:4000", ServerUrlKind::Api),
+            ("ws://127.0.0.1:4000", ServerUrlKind::WebSocket),
+            ("ws://[::1]:4000", ServerUrlKind::WebSocket),
+        ];
+
+        assert!(urls.into_iter().all(|(url, kind)| matches!(
+            validate_server_url(url, kind, false),
+            Ok(ServerUrlSecurity::LoopbackCleartext)
+        )));
+    }
+
+    #[test]
+    fn server_url_validation_rejects_remote_cleartext_api_without_opt_in() {
+        let error =
+            validate_server_url("http://dev.example.com", ServerUrlKind::Api, false).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("Cleartext Hooklistener API URLs are blocked")
+        );
+    }
+
+    #[test]
+    fn server_url_validation_rejects_remote_cleartext_websocket_without_opt_in() {
+        let error = validate_server_url("ws://dev.example.com", ServerUrlKind::WebSocket, false)
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("Cleartext Hooklistener WebSocket URLs are blocked")
+        );
+    }
+
+    #[test]
+    fn server_url_validation_accepts_remote_cleartext_with_explicit_dev_opt_in() {
+        let urls = [
+            ("http://dev.example.com", ServerUrlKind::Api),
+            ("ws://dev.example.com", ServerUrlKind::WebSocket),
+        ];
+
+        assert!(urls.into_iter().all(|(url, kind)| matches!(
+            validate_server_url(url, kind, true),
+            Ok(ServerUrlSecurity::ExplicitDevCleartext)
+        )));
+    }
+
+    #[test]
+    fn server_url_validation_rejects_unsupported_scheme() {
+        let error =
+            validate_server_url("ftp://dev.example.com", ServerUrlKind::Api, true).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("Unsupported Hooklistener API URL scheme 'ftp'")
+        );
+    }
+
+    #[test]
+    fn server_url_validation_rejects_malformed_url() {
+        let error = validate_server_url("not a URL", ServerUrlKind::Api, false).unwrap_err();
+
+        assert!(error.to_string().contains("Invalid Hooklistener API URL"));
+    }
+
+    #[test]
+    fn server_response_error_omits_unstructured_response_body() {
+        let error = server_response_error(
+            "Request failed",
+            StatusCode::BAD_GATEWAY,
+            "<html>secret\u{1b}]52;c;payload\u{7}</html>",
+        );
+
+        assert_eq!(error.to_string(), "Request failed (HTTP 502 Bad Gateway)");
+    }
+
+    #[test]
+    fn structured_server_error_detail_neutralizes_controls() {
+        let body = serde_json::json!({
+            "error": {
+                "code": "denied\nforged",
+                "message": "bad\u{1b}[31mrequest\r"
+            }
+        })
+        .to_string();
+
+        assert_eq!(
+            structured_server_error_detail(&body).as_deref(),
+            Some(r"code=denied\nforged; message=bad\u{1b}[31mrequest\r")
+        );
+    }
+
+    #[test]
+    fn structured_server_error_detail_is_bounded() {
+        let body = serde_json::json!({
+            "error": {"message": "x".repeat(MAX_SERVER_ERROR_DETAIL_BYTES * 2)}
+        })
+        .to_string();
+        let detail = structured_server_error_detail(&body).unwrap();
+
+        assert!(detail.len() <= MAX_SERVER_ERROR_DETAIL_BYTES);
+    }
 
     #[tokio::test]
     async fn relay_ticket_exchange_uses_authorization_header_and_parses_safe_receipt() {
@@ -1887,6 +2284,101 @@ mod tests {
             .unwrap();
         assert!(!result.success);
         assert!(result.error_message.is_some());
+    }
+
+    #[tokio::test]
+    async fn replay_rejects_non_loopback_target_before_sending() {
+        let client = ApiClient::for_forwarding().unwrap();
+        let request = replay_test_request("GET");
+
+        let error = client
+            .forward_request(&request, "http://169.254.169.254/latest/meta-data")
+            .await
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("target_non_loopback_requires_scope")
+        );
+    }
+
+    #[tokio::test]
+    async fn replay_does_not_follow_redirects() {
+        let mut server = mockito::Server::new_async().await;
+        let redirect = server
+            .mock("GET", "/start")
+            .with_status(302)
+            .with_header("location", "/unexpected")
+            .create_async()
+            .await;
+        let unexpected = server
+            .mock("GET", "/unexpected")
+            .expect(0)
+            .with_status(200)
+            .create_async()
+            .await;
+        let client = ApiClient::for_forwarding().unwrap();
+
+        let response = client
+            .forward_request(
+                &replay_test_request("GET"),
+                &format!("{}/start", server.url()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!((response.success, response.status_code), (true, Some(302)));
+        redirect.assert_async().await;
+        unexpected.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn replay_bounds_response_body_buffering() {
+        let mut server = mockito::Server::new_async().await;
+        let oversized_body = vec![b'x'; MAX_REPLAY_RESPONSE_BODY_BYTES + 1];
+        let response_mock = server
+            .mock("GET", "/large")
+            .with_status(200)
+            .with_body(oversized_body)
+            .create_async()
+            .await;
+        let client = ApiClient::for_forwarding().unwrap();
+
+        let response = client
+            .forward_request(
+                &replay_test_request("GET"),
+                &format!("{}/large", server.url()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.body,
+            format!("(Replay response body exceeded {MAX_REPLAY_RESPONSE_BODY_BYTES} bytes)")
+        );
+        response_mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn replay_connection_error_does_not_include_target_url() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        let sensitive_path = "sensitive-replay-target";
+        let target = format!("http://127.0.0.1:{port}/{sensitive_path}");
+        let client = ApiClient::for_forwarding().unwrap();
+
+        let response = client
+            .forward_request(&replay_test_request("POST"), &target)
+            .await
+            .unwrap();
+        let error = response.error_message.unwrap();
+
+        assert!(
+            !error.contains(sensitive_path),
+            "error exposed URL: {error}"
+        );
     }
 
     #[tokio::test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,6 +7,12 @@ use anyhow::{Result, anyhow};
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use ratatui::text::Span;
 use std::collections::{HashMap, VecDeque};
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 
 pub const MAX_LISTENING_REQUESTS: usize = 500;
 pub const MAX_TUNNEL_REQUESTS: usize = 500;
@@ -30,6 +36,32 @@ fn format_path_with_query(path: &str, query_string: &str) -> String {
         format!("{}?{}", path, query_string)
     }
 }
+
+#[cfg(any(not(windows), test))]
+fn posix_shell_quote(argument: &str) -> String {
+    format!("'{}'", argument.replace('\'', "'\\''"))
+}
+
+#[cfg(any(windows, test))]
+fn powershell_quote(argument: &str) -> String {
+    format!("'{}'", argument.replace('\'', "''"))
+}
+
+#[cfg(not(windows))]
+fn shell_quote(argument: &str) -> String {
+    posix_shell_quote(argument)
+}
+
+#[cfg(windows)]
+fn shell_quote(argument: &str) -> String {
+    powershell_quote(argument)
+}
+
+#[cfg(not(windows))]
+const SHELL_LINE_CONTINUATION: &str = " \\\n";
+
+#[cfg(windows)]
+const SHELL_LINE_CONTINUATION: &str = " `\r\n";
 
 #[derive(Debug)]
 pub enum AppState {
@@ -1389,7 +1421,7 @@ impl App {
 
     pub async fn forward_request(&mut self) -> Result<()> {
         if let Some(request) = &self.selected_request {
-            let client = ApiClient::for_forwarding();
+            let client = ApiClient::for_forwarding()?;
 
             match client
                 .forward_request(request, &self.forward_url_input)
@@ -1415,7 +1447,11 @@ impl App {
     }
 
     pub fn generate_curl(request: &WebhookRequest) -> String {
-        let mut parts = vec![format!("curl -X {} '{}'", request.method, request.url)];
+        let mut parts = vec![format!(
+            "curl --request {} --url {}",
+            shell_quote(&request.method),
+            shell_quote(&request.url)
+        )];
 
         let skip_headers = ["cf-", "x-forwarded", "host", "content-length", "x-real-ip"];
 
@@ -1427,8 +1463,10 @@ impl App {
             {
                 continue;
             }
-            let escaped_value = value.replace('\'', "'\\''");
-            parts.push(format!("  -H '{}: {}'", key, escaped_value));
+            parts.push(format!(
+                "  --header {}",
+                shell_quote(&format!("{key}: {value}"))
+            ));
         }
 
         let has_body_method = matches!(request.method.as_str(), "POST" | "PUT" | "PATCH");
@@ -1440,12 +1478,11 @@ impl App {
                 .cloned()
                 .unwrap_or_default();
             if !body.is_empty() {
-                let escaped_body = body.replace('\'', "'\\''");
-                parts.push(format!("  -d '{}'", escaped_body));
+                parts.push(format!("  --data-raw {}", shell_quote(&body)));
             }
         }
 
-        parts.join(" \\\n")
+        parts.join(SHELL_LINE_CONTINUATION)
     }
 
     pub fn generate_json_export(request: &WebhookRequest) -> Result<String> {
@@ -1466,13 +1503,25 @@ impl App {
         format!("hooklistener-{safe_id}.{extension}")
     }
 
-    fn save_export_fallback(
+    fn save_export_fallback(content: &str, request_id: &str, extension: &str) -> Result<PathBuf> {
+        Self::save_export_to_directory(content, request_id, extension, &std::env::current_dir()?)
+    }
+
+    fn save_export_to_directory(
         content: &str,
         request_id: &str,
         extension: &str,
-    ) -> Result<std::path::PathBuf> {
-        let path = std::env::current_dir()?.join(Self::export_filename(request_id, extension));
-        std::fs::write(&path, content)?;
+        directory: &Path,
+    ) -> Result<PathBuf> {
+        let path = directory.join(Self::export_filename(request_id, extension));
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        options.mode(0o600);
+
+        let mut file = options.open(&path)?;
+        file.write_all(content.as_bytes())?;
+        file.sync_all()?;
         Ok(path)
     }
 
@@ -3233,10 +3282,9 @@ mod tests {
     fn test_generate_curl_basic_get() {
         let request = make_request("GET", "https://example.com/hook");
         let curl = App::generate_curl(&request);
-        assert!(curl.contains("curl -X GET"));
+        assert!(curl.contains("curl --request 'GET' --url 'https://example.com/hook'"));
         assert!(curl.contains("https://example.com/hook"));
-        // GET should not have -d
-        assert!(!curl.contains("-d"));
+        assert!(!curl.contains("--data-raw"));
     }
 
     #[test]
@@ -3250,9 +3298,42 @@ mod tests {
         request.body = Some(r#"{"key":"value"}"#.to_string());
 
         let curl = App::generate_curl(&request);
-        assert!(curl.contains("curl -X POST"));
-        assert!(curl.contains("-d"));
-        assert!(curl.contains("-H 'content-type: application/json'"));
+        assert!(curl.contains("curl --request 'POST'"));
+        assert!(curl.contains("--data-raw"));
+        assert!(curl.contains("--header 'content-type: application/json'"));
+    }
+
+    #[test]
+    fn generate_curl_shell_quotes_remote_derived_arguments() {
+        let request = make_request_with_headers(
+            "POST'; touch /tmp/method #",
+            "https://example.com/'$(touch /tmp/url)",
+            vec![("x-'header", "value'; touch /tmp/header #")],
+        );
+
+        let curl = App::generate_curl(&request);
+
+        assert!(curl.contains("--request 'POST'\\''; touch /tmp/method #'"));
+        assert!(curl.contains("--url 'https://example.com/'\\''$(touch /tmp/url)'"));
+        assert!(curl.contains("--header 'x-'\\''header: value'\\''; touch /tmp/header #'"));
+    }
+
+    #[test]
+    fn powershell_quote_keeps_command_separators_inside_one_argument() {
+        assert_eq!(
+            powershell_quote("GET'; Start-Process calc; #"),
+            "'GET''; Start-Process calc; #'"
+        );
+    }
+
+    #[test]
+    fn generate_curl_uses_data_raw_for_at_prefixed_body() {
+        let mut request = make_request("POST", "https://example.com/hook");
+        request.body = Some("@/etc/passwd".to_string());
+
+        let curl = App::generate_curl(&request);
+
+        assert!(curl.contains("--data-raw '@/etc/passwd'"));
     }
 
     #[test]
@@ -3378,6 +3459,38 @@ mod tests {
             App::export_filename("req/../../unsafe", "json"),
             "hooklistener-req_______unsafe.json"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_export_to_directory_creates_private_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let path =
+            App::save_export_to_directory("secret", "request", "json", directory.path()).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_export_to_directory_refuses_preexisting_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("target");
+        std::fs::write(&target, "unchanged").unwrap();
+        let export = directory.path().join("hooklistener-request.json");
+        symlink(&target, &export).unwrap();
+
+        let result = App::save_export_to_directory("secret", "request", "json", directory.path());
+
+        assert!(result.is_err());
+        assert_eq!(std::fs::read_to_string(target).unwrap(), "unchanged");
     }
 
     #[test]

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,12 +1,21 @@
 use anyhow::{Result, anyhow};
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
+use std::time::Duration as StdDuration;
+use tokio::time::Instant;
+
+const DEFAULT_POLL_INTERVAL: StdDuration = StdDuration::from_secs(5);
+const SLOW_DOWN_INCREMENT: StdDuration = StdDuration::from_secs(5);
+const MAX_AUTH_RESPONSE_BYTES: usize = 16 * 1024;
+const MAX_ERROR_DETAIL_CHARS: usize = 240;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DeviceCodeResponse {
     pub device_code: String,
     pub user_code: String,
     pub expires_in: u64,
+    #[serde(default)]
+    pub interval: Option<u64>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -32,6 +41,8 @@ pub struct DeviceCodeFlow {
     device_code: Option<String>,
     user_code: Option<String>,
     expires_at: Option<DateTime<Utc>>,
+    poll_interval: StdDuration,
+    next_poll_at: Option<Instant>,
 }
 
 impl DeviceCodeFlow {
@@ -42,6 +53,8 @@ impl DeviceCodeFlow {
             device_code: None,
             user_code: None,
             expires_at: None,
+            poll_interval: DEFAULT_POLL_INTERVAL,
+            next_poll_at: None,
         }
     }
 
@@ -53,7 +66,8 @@ impl DeviceCodeFlow {
             .post(&url)
             .header("Content-Type", "application/json")
             .send()
-            .await?;
+            .await
+            .map_err(|error| Self::request_error("Failed to initiate device flow", error, None))?;
 
         if !response.status().is_success() {
             return Err(anyhow!(
@@ -62,53 +76,170 @@ impl DeviceCodeFlow {
             ));
         }
 
-        let device_response: DeviceCodeResponse = response.json().await?;
+        let body = Self::read_bounded_response(response, None).await?;
+        let device_response: DeviceCodeResponse = serde_json::from_slice(&body).map_err(|_| {
+            anyhow!("Authorization server returned an invalid device flow response")
+        })?;
 
         self.device_code = Some(device_response.device_code.clone());
         self.user_code = Some(device_response.user_code.clone());
         self.expires_at = Some(Utc::now() + Duration::seconds(device_response.expires_in as i64));
+        self.poll_interval = StdDuration::from_secs(
+            device_response
+                .interval
+                .unwrap_or(DEFAULT_POLL_INTERVAL.as_secs()),
+        );
+        self.schedule_next_poll()?;
 
         Ok(device_response.user_code)
     }
 
-    pub async fn poll_for_authorization(&self) -> Result<Option<TokenResponse>> {
+    pub async fn poll_for_authorization(&mut self) -> Result<Option<TokenResponse>> {
         let device_code = self
             .device_code
-            .as_ref()
+            .clone()
             .ok_or_else(|| anyhow!("No device code available"))?;
 
-        let url = format!(
-            "{}/api/v1/device?device_code={}",
-            self.base_url, device_code
-        );
-
-        let response = self.client.get(&url).send().await?;
-
-        match response.status().as_u16() {
-            200 => {
-                let text = response.text().await?;
-
-                if let Ok(token_response) = serde_json::from_str::<TokenResponse>(&text) {
-                    if token_response.access_token.is_empty() {
-                        // No access_token means it parsed a pending response
-                        Err(anyhow!("Unexpected response format"))
-                    } else {
-                        Ok(Some(token_response))
-                    }
-                } else if let Ok(pending_response) = serde_json::from_str::<PendingResponse>(&text)
-                {
-                    if pending_response.error == "authorization_pending" {
-                        Ok(None)
-                    } else {
-                        Err(anyhow!("Authorization error: {}", pending_response.error))
-                    }
-                } else {
-                    Err(anyhow!("Unexpected response format"))
-                }
-            }
-            404 => Err(anyhow!("Device code not found or expired")),
-            _ => Err(anyhow!("Polling failed: {}", response.status())),
+        if !self.poll_is_due() {
+            return Ok(None);
         }
+        self.next_poll_at = None;
+
+        let mut url = reqwest::Url::parse(&format!("{}/api/v1/device", self.base_url))
+            .map_err(|_| anyhow!("Invalid authorization server URL"))?;
+        url.query_pairs_mut()
+            .append_pair("device_code", &device_code);
+        // The deployed endpoint contract is GET with a query parameter. Url encodes the
+        // opaque code, and every request error below removes both the URL and the code.
+        let response = self.client.get(url).send().await.map_err(|error| {
+            Self::request_error(
+                "Device authorization request failed",
+                error,
+                Some(&device_code),
+            )
+        })?;
+        let status = response.status();
+
+        if status.as_u16() == 404 {
+            return Err(anyhow!("Device code not found or expired"));
+        }
+
+        let body = Self::read_bounded_response(response, Some(&device_code)).await?;
+        if matches!(status.as_u16(), 200 | 400)
+            && let Ok(pending_response) = serde_json::from_slice::<PendingResponse>(&body)
+        {
+            return self.handle_authorization_error(&pending_response.error);
+        }
+
+        if status.is_success() {
+            if let Ok(token_response) = serde_json::from_slice::<TokenResponse>(&body) {
+                if token_response.access_token.is_empty() {
+                    Err(anyhow!("Unexpected response format"))
+                } else {
+                    Ok(Some(token_response))
+                }
+            } else {
+                Err(anyhow!("Unexpected response format"))
+            }
+        } else {
+            Err(anyhow!("Polling failed: {status}"))
+        }
+    }
+
+    pub fn time_until_next_poll(&self) -> StdDuration {
+        Self::poll_delay_at(self.next_poll_at, Instant::now())
+    }
+
+    fn poll_is_due(&self) -> bool {
+        self.time_until_next_poll().is_zero()
+    }
+
+    fn poll_delay_at(next_poll_at: Option<Instant>, now: Instant) -> StdDuration {
+        next_poll_at.map_or(StdDuration::ZERO, |deadline| {
+            deadline.saturating_duration_since(now)
+        })
+    }
+
+    fn schedule_next_poll(&mut self) -> Result<()> {
+        self.next_poll_at = Some(
+            Instant::now()
+                .checked_add(self.poll_interval)
+                .ok_or_else(|| anyhow!("Authorization polling interval is too large"))?,
+        );
+        Ok(())
+    }
+
+    fn handle_authorization_error(&mut self, error: &str) -> Result<Option<TokenResponse>> {
+        match error {
+            "authorization_pending" => {
+                self.schedule_next_poll()?;
+                Ok(None)
+            }
+            "slow_down" => {
+                self.poll_interval = self
+                    .poll_interval
+                    .checked_add(SLOW_DOWN_INCREMENT)
+                    .ok_or_else(|| anyhow!("Authorization polling interval is too large"))?;
+                self.schedule_next_poll()?;
+                Ok(None)
+            }
+            "access_denied" => Err(anyhow!("Device authorization was denied")),
+            "expired_token" => Err(anyhow!("Device code not found or expired")),
+            _ => Err(anyhow!(
+                "Authorization server returned an unrecognized error"
+            )),
+        }
+    }
+
+    async fn read_bounded_response(
+        mut response: reqwest::Response,
+        secret: Option<&str>,
+    ) -> Result<Vec<u8>> {
+        if response
+            .content_length()
+            .is_some_and(|length| length > MAX_AUTH_RESPONSE_BYTES as u64)
+        {
+            return Err(anyhow!(
+                "Authorization server response exceeded {MAX_AUTH_RESPONSE_BYTES} bytes"
+            ));
+        }
+
+        let mut body = Vec::new();
+        while let Some(chunk) = response.chunk().await.map_err(|error| {
+            Self::request_error("Failed to read authorization response", error, secret)
+        })? {
+            if chunk.len() > MAX_AUTH_RESPONSE_BYTES.saturating_sub(body.len()) {
+                return Err(anyhow!(
+                    "Authorization server response exceeded {MAX_AUTH_RESPONSE_BYTES} bytes"
+                ));
+            }
+            body.extend_from_slice(&chunk);
+        }
+        Ok(body)
+    }
+
+    fn request_error(context: &str, error: reqwest::Error, secret: Option<&str>) -> anyhow::Error {
+        let mut detail = error.without_url().to_string();
+        if let Some(secret) = secret.filter(|secret| !secret.is_empty()) {
+            detail = detail.replace(secret, "[REDACTED]");
+        }
+        anyhow!("{context}: {}", Self::sanitize_error_detail(&detail))
+    }
+
+    fn sanitize_error_detail(detail: &str) -> String {
+        let mut sanitized = String::new();
+        let mut chars = detail.chars();
+        for character in chars.by_ref().take(MAX_ERROR_DETAIL_CHARS) {
+            if character.is_control() {
+                sanitized.push('\u{fffd}');
+            } else {
+                sanitized.push(character);
+            }
+        }
+        if chars.next().is_some() {
+            sanitized.push('…');
+        }
+        sanitized
     }
 
     pub fn format_user_code(&self) -> Option<String> {
@@ -172,6 +303,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn initiate_device_flow_uses_server_poll_interval() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/api/v1/device")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"device_code":"dev123","user_code":"ABCD1234","expires_in":600,"interval":11}"#,
+            )
+            .create_async()
+            .await;
+
+        let mut flow = DeviceCodeFlow::new(server.url());
+        flow.initiate_device_flow().await.unwrap();
+
+        assert_eq!(
+            (flow.poll_interval, flow.next_poll_at.is_some()),
+            (StdDuration::from_secs(11), true)
+        );
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn initiate_device_flow_defaults_to_five_second_poll_interval() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/api/v1/device")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"device_code":"dev123","user_code":"ABCD1234","expires_in":600}"#)
+            .create_async()
+            .await;
+
+        let mut flow = DeviceCodeFlow::new(server.url());
+        flow.initiate_device_flow().await.unwrap();
+
+        assert_eq!(flow.poll_interval, DEFAULT_POLL_INTERVAL);
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
     async fn test_poll_for_authorization_pending() {
         let mut server = mockito::Server::new_async().await;
         let mock = server
@@ -211,6 +383,171 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn poll_for_authorization_percent_encodes_device_code_query_value() {
+        let mut server = mockito::Server::new_async().await;
+        let device_code = "device code&admin=true";
+        let mock = server
+            .mock("GET", "/api/v1/device")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "device_code".to_string(),
+                device_code.to_string(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"error":"authorization_pending"}"#)
+            .create_async()
+            .await;
+
+        let mut flow = DeviceCodeFlow::new(server.url());
+        flow.device_code = Some(device_code.to_string());
+        flow.poll_for_authorization().await.unwrap();
+
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn poll_for_authorization_slow_down_adds_five_seconds() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/api/v1/device?device_code=dev123")
+            .with_status(400)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"error":"slow_down"}"#)
+            .create_async()
+            .await;
+
+        let mut flow = DeviceCodeFlow::new(server.url());
+        flow.device_code = Some("dev123".to_string());
+        let result = flow.poll_for_authorization().await.unwrap();
+
+        assert_eq!(
+            (
+                result.is_none(),
+                flow.poll_interval,
+                flow.next_poll_at.is_some(),
+            ),
+            (true, StdDuration::from_secs(10), true)
+        );
+        mock.assert_async().await;
+    }
+
+    #[test]
+    fn repeated_slow_down_responses_keep_increasing_poll_interval() {
+        let mut flow = DeviceCodeFlow::new("http://localhost".to_string());
+
+        flow.handle_authorization_error("slow_down").unwrap();
+        flow.handle_authorization_error("slow_down").unwrap();
+
+        assert_eq!(flow.poll_interval, StdDuration::from_secs(15));
+    }
+
+    #[test]
+    fn authorization_pending_preserves_poll_interval() {
+        let mut flow = DeviceCodeFlow::new("http://localhost".to_string());
+        flow.poll_interval = StdDuration::from_secs(9);
+
+        flow.handle_authorization_error("authorization_pending")
+            .unwrap();
+
+        assert_eq!(flow.poll_interval, StdDuration::from_secs(9));
+    }
+
+    #[test]
+    fn time_until_next_poll_reports_configured_interval() {
+        let now = Instant::now();
+        let deadline = now + StdDuration::from_secs(9);
+
+        let delay = DeviceCodeFlow::poll_delay_at(Some(deadline), now);
+
+        assert_eq!(delay, StdDuration::from_secs(9));
+    }
+
+    #[tokio::test]
+    async fn poll_transport_error_does_not_expose_device_code() {
+        let device_code = "sensitive-device-code";
+        let mut flow = DeviceCodeFlow::new("://invalid-base-url".to_string());
+        flow.device_code = Some(device_code.to_string());
+
+        let error = flow.poll_for_authorization().await.unwrap_err().to_string();
+
+        assert!(
+            !error.contains(device_code),
+            "error exposed device code: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_before_deadline_returns_without_sending_request() {
+        let mut flow = DeviceCodeFlow::new("://invalid-base-url".to_string());
+        flow.device_code = Some("dev123".to_string());
+        flow.next_poll_at = Some(Instant::now() + StdDuration::from_secs(60));
+
+        let result = flow.poll_for_authorization().await.unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn poll_unknown_remote_error_is_not_exposed() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/api/v1/device?device_code=dev123")
+            .with_status(400)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"error":"secret-body\u001b]52;c;clipboard"}"#)
+            .create_async()
+            .await;
+
+        let mut flow = DeviceCodeFlow::new(server.url());
+        flow.device_code = Some("dev123".to_string());
+        let error = flow.poll_for_authorization().await.unwrap_err().to_string();
+
+        assert_eq!(error, "Authorization server returned an unrecognized error");
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn poll_rejects_oversized_remote_error_body_without_exposing_it() {
+        let mut server = mockito::Server::new_async().await;
+        let secret = "remote-error-secret";
+        let body = format!("{secret}{}", "x".repeat(MAX_AUTH_RESPONSE_BYTES));
+        let mock = server
+            .mock("GET", "/api/v1/device?device_code=dev123")
+            .with_status(500)
+            .with_body(body)
+            .create_async()
+            .await;
+
+        let mut flow = DeviceCodeFlow::new(server.url());
+        flow.device_code = Some("dev123".to_string());
+        let error = flow.poll_for_authorization().await.unwrap_err().to_string();
+
+        assert_eq!(
+            error,
+            format!("Authorization server response exceeded {MAX_AUTH_RESPONSE_BYTES} bytes")
+        );
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn poll_http_error_does_not_expose_bounded_remote_body() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/api/v1/device?device_code=dev123")
+            .with_status(500)
+            .with_body("secret remote body\u{1b}]52;c;clipboard")
+            .create_async()
+            .await;
+
+        let mut flow = DeviceCodeFlow::new(server.url());
+        flow.device_code = Some("dev123".to_string());
+        let error = flow.poll_for_authorization().await.unwrap_err().to_string();
+
+        assert_eq!(error, "Polling failed: 500 Internal Server Error");
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
     async fn test_poll_for_authorization_expired() {
         let mut server = mockito::Server::new_async().await;
         let mock = server
@@ -230,7 +567,7 @@ mod tests {
     #[tokio::test]
     async fn test_poll_without_device_code_errors() {
         let server = mockito::Server::new_async().await;
-        let flow = DeviceCodeFlow::new(server.url());
+        let mut flow = DeviceCodeFlow::new(server.url());
         let result = flow.poll_for_authorization().await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("No device code"));

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,11 @@ use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
+#[cfg(unix)]
+use std::fs::File;
+#[cfg(unix)]
+use std::io::Read;
+
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct Config {
     pub access_token: Option<String>,
@@ -27,19 +32,27 @@ impl Config {
     }
 
     pub fn load_from(path: &Path) -> Result<Self> {
-        if path.exists() {
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-                fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+        let metadata = match fs::symlink_metadata(path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(Config::default());
             }
-
-            let content = fs::read_to_string(path)?;
-            let config: Config = serde_json::from_str(&content)?;
-            Ok(config)
-        } else {
-            Ok(Config::default())
+            Err(error) => return Err(error.into()),
+        };
+        if !metadata.file_type().is_file() {
+            return Err(anyhow::anyhow!(
+                "Config path must be a regular file and must not be a symlink"
+            ));
         }
+
+        #[cfg(unix)]
+        let content = read_private_config_file(path)?;
+
+        #[cfg(not(unix))]
+        let content = fs::read_to_string(path)?;
+
+        let config: Config = serde_json::from_str(&content)?;
+        Ok(config)
     }
 
     pub fn save(&self) -> Result<()> {
@@ -167,6 +180,28 @@ impl Config {
     pub fn clear_all(&mut self) {
         *self = Config::default();
     }
+}
+
+#[cfg(unix)]
+fn read_private_config_file(path: &Path) -> Result<String> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let mut file = File::open(path)?;
+    let opened_metadata = file.metadata()?;
+    let current_metadata = fs::symlink_metadata(path)?;
+    if !current_metadata.file_type().is_file()
+        || opened_metadata.dev() != current_metadata.dev()
+        || opened_metadata.ino() != current_metadata.ino()
+    {
+        return Err(anyhow::anyhow!(
+            "Config path changed while it was being opened"
+        ));
+    }
+
+    file.set_permissions(fs::Permissions::from_mode(0o600))?;
+    let mut content = String::new();
+    file.read_to_string(&mut content)?;
+    Ok(content)
 }
 
 #[cfg(windows)]
@@ -596,5 +631,26 @@ mod tests {
 
         let result = Config::load_from(&path);
         assert!(result.is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_from_refuses_symlink_without_changing_target_permissions() {
+        use std::os::unix::fs::{PermissionsExt, symlink};
+
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("target.json");
+        fs::write(&target, "{}").unwrap();
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o644)).unwrap();
+        let path = config_path_in(&dir);
+        symlink(&target, &path).unwrap();
+
+        let result = Config::load_from(&path);
+
+        assert!(result.is_err());
+        assert_eq!(
+            fs::metadata(target).unwrap().permissions().mode() & 0o777,
+            0o644
+        );
     }
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
 use chrono::Utc;
 use std::cmp::Reverse;
-use std::fs;
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use tracing::{info, warn};
 use tracing_appender::non_blocking::WorkerGuard;
@@ -45,21 +46,22 @@ impl Logger {
     pub fn new(config: LogConfig) -> Result<Self> {
         let session_id = Uuid::new_v4();
 
-        // Create log directory if it doesn't exist
-        fs::create_dir_all(&config.directory)?;
+        Self::ensure_private_directory(&config.directory)?;
+        #[cfg(unix)]
+        Self::harden_existing_log_files(&config.directory)?;
 
         // Clean up old log files
         let _ = Self::cleanup_old_logs(&config.directory, config.max_log_files)?;
 
         let log_file_path = config.directory.join(format!(
-            "hooklistener-{}.log",
-            Utc::now().format("%Y%m%d-%H%M%S")
+            "hooklistener-{}-{session_id}.log",
+            Utc::now().format("%Y%m%d-%H%M%S"),
         ));
 
-        // Create file appender
-        let file_appender =
-            tracing_appender::rolling::never(&config.directory, log_file_path.file_name().unwrap());
-        let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+        // Supplying the already-opened file prevents tracing-appender from creating it
+        // with process-umask-dependent permissions.
+        let log_file = Self::open_private_file(&log_file_path)?;
+        let (non_blocking, guard) = tracing_appender::non_blocking(log_file);
 
         // Create filter
         let filter =
@@ -168,19 +170,14 @@ impl Logger {
             "Creating diagnostic bundle"
         );
 
-        // Create a directory for the diagnostic bundle
-        let bundle_dir = bundle_path.join(format!(
-            "hooklistener-diagnostics-{}",
-            Utc::now().format("%Y%m%d-%H%M%S")
-        ));
-        fs::create_dir_all(&bundle_dir)?;
+        let bundle_dir = Self::create_unique_bundle_directory(bundle_path)?;
 
         // Write this first so a useful bundle remains even when optional inputs are corrupt.
         let system_info = self.collect_system_info();
         let system_info_path = bundle_dir.join("system_info.json");
-        fs::write(
-            system_info_path,
-            serde_json::to_string_pretty(&system_info)?,
+        Self::write_private_file(
+            &system_info_path,
+            serde_json::to_string_pretty(&system_info)?.as_bytes(),
         )?;
 
         let config_path = crate::config::Config::config_path()?;
@@ -207,7 +204,7 @@ impl Logger {
 
         if log_dir.exists() {
             let log_bundle_dir = bundle_dir.join("logs");
-            fs::create_dir_all(&log_bundle_dir)?;
+            Self::create_private_directory(&log_bundle_dir)?;
             if let Err(error) = Self::copy_log_files(&log_dir, &log_bundle_dir, &tokens) {
                 warn!(error = %error, "Unable to enumerate diagnostic logs");
             }
@@ -216,7 +213,9 @@ impl Logger {
         // Copy sanitized config
         if let Some(sanitized_config) = sanitized_config {
             let config_bundle_path = bundle_dir.join("config.json");
-            if let Err(error) = fs::write(config_bundle_path, sanitized_config) {
+            if let Err(error) =
+                Self::write_private_file(&config_bundle_path, sanitized_config.as_bytes())
+            {
                 warn!(error = %error, "Unable to write sanitized diagnostic config");
             }
         }
@@ -227,6 +226,113 @@ impl Logger {
             "Diagnostic bundle created successfully"
         );
 
+        Ok(())
+    }
+
+    fn ensure_private_directory(path: &Path) -> Result<()> {
+        fs::create_dir_all(path)?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            // Apply permissions through the opened directory descriptor so a later path
+            // replacement cannot redirect the chmod operation.
+            let directory = File::open(path)?;
+            if !directory.metadata()?.is_dir() {
+                anyhow::bail!("{} is not a directory", path.display());
+            }
+            directory.set_permissions(fs::Permissions::from_mode(0o700))?;
+        }
+
+        Ok(())
+    }
+
+    fn create_private_directory(path: &Path) -> std::io::Result<()> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+
+            let mut builder = fs::DirBuilder::new();
+            builder.mode(0o700).create(path)?;
+            let directory = File::open(path)?;
+            directory.set_permissions(fs::Permissions::from_mode(0o700))?;
+        }
+
+        #[cfg(not(unix))]
+        fs::create_dir(path)?;
+
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    fn harden_existing_log_files(log_dir: &Path) -> Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        for entry in fs::read_dir(log_dir)? {
+            let entry = entry?;
+            let file_name = entry.file_name();
+            if !entry.file_type()?.is_file()
+                || !file_name
+                    .to_str()
+                    .is_some_and(|name| name.starts_with("hooklistener-"))
+                || Path::new(&file_name)
+                    .extension()
+                    .is_none_or(|extension| extension != "log")
+            {
+                continue;
+            }
+
+            // DirEntry::file_type does not follow symlinks. The directory is already
+            // owner-only, and chmod is applied through the opened file descriptor.
+            let file = File::open(entry.path())?;
+            file.set_permissions(fs::Permissions::from_mode(0o600))?;
+        }
+
+        Ok(())
+    }
+
+    fn create_unique_bundle_directory(bundle_path: &Path) -> Result<PathBuf> {
+        const MAX_ATTEMPTS: usize = 8;
+
+        fs::create_dir_all(bundle_path)?;
+        for _ in 0..MAX_ATTEMPTS {
+            let bundle_dir = bundle_path.join(format!(
+                "hooklistener-diagnostics-{}-{}",
+                Utc::now().format("%Y%m%d-%H%M%S"),
+                Uuid::new_v4()
+            ));
+            match Self::create_private_directory(&bundle_dir) {
+                Ok(()) => return Ok(bundle_dir),
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(error) => return Err(error.into()),
+            }
+        }
+
+        anyhow::bail!("Could not allocate a unique diagnostic bundle directory")
+    }
+
+    fn open_private_file(path: &Path) -> std::io::Result<File> {
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+            options.mode(0o600);
+            let file = options.open(path)?;
+            file.set_permissions(fs::Permissions::from_mode(0o600))?;
+            Ok(file)
+        }
+
+        #[cfg(not(unix))]
+        options.open(path)
+    }
+
+    fn write_private_file(path: &Path, contents: &[u8]) -> Result<()> {
+        let mut file = Self::open_private_file(path)?;
+        file.write_all(contents)?;
         Ok(())
     }
 
@@ -243,7 +349,7 @@ impl Logger {
             let Some(file_name) = path.file_name() else {
                 continue;
             };
-            if !path.is_file()
+            if !entry.file_type()?.is_file()
                 || !file_name
                     .to_str()
                     .is_some_and(|name| name.starts_with("hooklistener-"))
@@ -271,15 +377,7 @@ impl Logger {
             contents = Self::replace_bytes(&contents, token, b"[REDACTED]");
         }
 
-        let temp = dest.with_file_name(format!(
-            ".{}.{}.tmp",
-            dest.file_name().unwrap_or_default().to_string_lossy(),
-            Uuid::new_v4()
-        ));
-        if let Err(error) = fs::write(&temp, contents).and_then(|()| fs::rename(&temp, dest)) {
-            let _ = fs::remove_file(&temp);
-            return Err(error.into());
-        }
+        Self::write_private_file(dest, &contents)?;
         Ok(())
     }
 
@@ -299,16 +397,37 @@ impl Logger {
     }
 
     fn read_config_for_bundle(config_path: &Path) -> Result<(Option<String>, Vec<Vec<u8>>)> {
-        let content = fs::read_to_string(config_path)?;
+        let content = Self::read_regular_file(config_path)?;
         let config: serde_json::Value = serde_json::from_str(&content)?;
         serde_json::from_value::<crate::config::Config>(config.clone())
             .map_err(|_| anyhow::anyhow!("Config unavailable or invalid"))?;
-        let tokens = ["access_token", "refresh_token"]
-            .into_iter()
-            .filter_map(|key| config.get(key)?.as_str())
-            .map(|token| token.as_bytes().to_vec())
-            .collect();
-        Ok((Some(Self::sanitize_config(config)?), tokens))
+        let (sanitized, tokens) = Self::sanitize_config_with_secrets(config)?;
+        Ok((Some(sanitized), tokens))
+    }
+
+    fn read_regular_file(path: &Path) -> Result<String> {
+        let mut file = File::open(path)?;
+        let opened_metadata = file.metadata()?;
+        let current_metadata = fs::symlink_metadata(path)?;
+
+        if !opened_metadata.is_file() || !current_metadata.file_type().is_file() {
+            anyhow::bail!("Diagnostic config must be a regular file and must not be a symlink");
+        }
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+
+            if opened_metadata.dev() != current_metadata.dev()
+                || opened_metadata.ino() != current_metadata.ino()
+            {
+                anyhow::bail!("Diagnostic config changed while it was being opened");
+            }
+        }
+
+        let mut content = String::new();
+        file.read_to_string(&mut content)?;
+        Ok(content)
     }
 
     #[cfg(test)]
@@ -318,20 +437,95 @@ impl Logger {
         Self::sanitize_config(config)
     }
 
+    #[cfg(test)]
     fn sanitize_config(mut config: serde_json::Value) -> Result<String> {
-        // Remove sensitive data
-        if let Some(obj) = config.as_object_mut() {
-            obj.remove("access_token");
-            obj.remove("refresh_token");
-            if let Some(token_expires) = obj.get_mut("token_expires_at") {
-                *token_expires = serde_json::Value::String("[REDACTED]".to_string());
-            }
-            if let Some(token_expires) = obj.get_mut("refresh_token_expires_at") {
-                *token_expires = serde_json::Value::String("[REDACTED]".to_string());
-            }
-        }
+        let mut secrets = Vec::new();
+        Self::redact_config_value(&mut config, &mut secrets);
 
         Ok(serde_json::to_string_pretty(&config)?)
+    }
+
+    fn sanitize_config_with_secrets(
+        mut config: serde_json::Value,
+    ) -> Result<(String, Vec<Vec<u8>>)> {
+        let mut secrets = Vec::new();
+        Self::redact_config_value(&mut config, &mut secrets);
+        Ok((serde_json::to_string_pretty(&config)?, secrets))
+    }
+
+    fn redact_config_value(value: &mut serde_json::Value, secrets: &mut Vec<Vec<u8>>) {
+        match value {
+            serde_json::Value::Object(object) => {
+                let keys: Vec<_> = object.keys().cloned().collect();
+                for key in keys {
+                    if Self::is_token_expiry_key(&key) {
+                        if let Some(value) = object.get_mut(&key) {
+                            *value = serde_json::Value::String("[REDACTED]".to_string());
+                        }
+                    } else if Self::is_secret_config_key(&key) {
+                        if let Some(secret) = object.remove(&key) {
+                            Self::collect_secret_values(&secret, secrets);
+                        }
+                    } else if let Some(value) = object.get_mut(&key) {
+                        Self::redact_config_value(value, secrets);
+                    }
+                }
+            }
+            serde_json::Value::Array(values) => {
+                for value in values {
+                    Self::redact_config_value(value, secrets);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn collect_secret_values(value: &serde_json::Value, secrets: &mut Vec<Vec<u8>>) {
+        match value {
+            serde_json::Value::String(secret) if !secret.is_empty() => {
+                secrets.push(secret.as_bytes().to_vec());
+            }
+            serde_json::Value::Array(values) => {
+                for value in values {
+                    Self::collect_secret_values(value, secrets);
+                }
+            }
+            serde_json::Value::Object(object) => {
+                for value in object.values() {
+                    Self::collect_secret_values(value, secrets);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn normalized_config_key(key: &str) -> String {
+        key.to_ascii_lowercase().replace(['-', ' '], "_")
+    }
+
+    fn is_token_expiry_key(key: &str) -> bool {
+        let key = Self::normalized_config_key(key);
+        key.contains("token") && (key.contains("expires") || key.contains("expiration"))
+    }
+
+    fn is_secret_config_key(key: &str) -> bool {
+        let key = Self::normalized_config_key(key);
+        key == "token"
+            || key == "tokens"
+            || key.ends_with("token")
+            || key.ends_with("_tokens")
+            || key.starts_with("access_token")
+            || key.starts_with("refresh_token")
+            || key.starts_with("session_token")
+            || key.starts_with("auth_token")
+            || key.starts_with("bearer_token")
+            || key.starts_with("id_token")
+            || key == "secret"
+            || key.ends_with("_secret")
+            || key == "password"
+            || key.ends_with("_password")
+            || key == "api_key"
+            || key.ends_with("_api_key")
     }
 
     fn collect_system_info(&self) -> serde_json::Value {
@@ -473,6 +667,65 @@ mod tests {
     }
 
     #[test]
+    fn sanitize_config_recursively_removes_future_secret_fields() {
+        let config = serde_json::json!({
+            "refreshToken": "refresh-secret",
+            "refreshTokenExpiration": "2030-01-01T00:00:00Z",
+            "nested": [{
+                "session_token": "session-secret",
+                "client_secret": "client-secret",
+                "api_key": "api-key-secret",
+                "token_type": "Bearer"
+            }],
+            "theme": "dark"
+        });
+
+        let sanitized = Logger::sanitize_config(config).unwrap();
+        let sanitized: serde_json::Value = serde_json::from_str(&sanitized).unwrap();
+
+        assert_eq!(
+            sanitized,
+            serde_json::json!({
+                "refreshTokenExpiration": "[REDACTED]",
+                "nested": [{ "token_type": "Bearer" }],
+                "theme": "dark"
+            })
+        );
+    }
+
+    #[test]
+    fn read_config_for_bundle_collects_all_removed_secrets_for_log_redaction() {
+        use std::collections::BTreeSet;
+
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join("config.json");
+        fs::write(
+            &config_path,
+            r#"{
+                "access_token": "access-secret",
+                "refresh_token": "refresh-secret",
+                "nested": { "api_token": "api-secret" }
+            }"#,
+        )
+        .unwrap();
+
+        let (_, secrets) = Logger::read_config_for_bundle(&config_path).unwrap();
+        let secrets: BTreeSet<_> = secrets
+            .into_iter()
+            .map(|secret| String::from_utf8(secret).unwrap())
+            .collect();
+
+        assert_eq!(
+            secrets,
+            BTreeSet::from([
+                "access-secret".to_string(),
+                "api-secret".to_string(),
+                "refresh-secret".to_string(),
+            ])
+        );
+    }
+
+    #[test]
     fn read_config_for_bundle_rejects_wrong_json_shape_without_exposing_content() {
         let dir = TempDir::new().unwrap();
         let config_path = dir.path().join("config.json");
@@ -484,6 +737,30 @@ mod tests {
             .to_string();
 
         assert_eq!(error, "Config unavailable or invalid");
+        assert!(!error.contains(secret));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_config_for_bundle_rejects_symlink_without_exposing_target() {
+        use std::os::unix::fs::symlink;
+
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("target.json");
+        let config_path = dir.path().join("config.json");
+        let secret = "symlink-target-secret";
+        fs::write(
+            &target,
+            format!(r#"{{"access_token":"{secret}","leaked":"target contents"}}"#),
+        )
+        .unwrap();
+        symlink(&target, &config_path).unwrap();
+
+        let error = Logger::read_config_for_bundle(&config_path)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("must not be a symlink"));
         assert!(!error.contains(secret));
     }
 
@@ -591,6 +868,155 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn ensure_private_directory_sets_owner_only_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().unwrap();
+        let logs = dir.path().join("logs");
+        fs::create_dir(&logs).unwrap();
+        fs::set_permissions(&logs, fs::Permissions::from_mode(0o755)).unwrap();
+
+        Logger::ensure_private_directory(&logs).unwrap();
+
+        assert_eq!(
+            fs::metadata(logs).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_private_file_creates_owner_only_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("private.log");
+
+        drop(Logger::open_private_file(&path).unwrap());
+
+        assert_eq!(
+            fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn harden_existing_log_files_updates_regular_files_without_following_symlinks() {
+        use std::os::unix::fs::{PermissionsExt, symlink};
+
+        let dir = TempDir::new().unwrap();
+        let log = dir.path().join("hooklistener-existing.log");
+        let victim = dir.path().join("victim");
+        let linked_log = dir.path().join("hooklistener-linked.log");
+        fs::write(&log, "log").unwrap();
+        fs::write(&victim, "victim").unwrap();
+        fs::set_permissions(&log, fs::Permissions::from_mode(0o644)).unwrap();
+        fs::set_permissions(&victim, fs::Permissions::from_mode(0o644)).unwrap();
+        symlink(&victim, linked_log).unwrap();
+
+        Logger::harden_existing_log_files(dir.path()).unwrap();
+
+        assert_eq!(
+            (
+                fs::metadata(log).unwrap().permissions().mode() & 0o777,
+                fs::metadata(victim).unwrap().permissions().mode() & 0o777,
+            ),
+            (0o600, 0o644)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_private_file_refuses_preexisting_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let dir = TempDir::new().unwrap();
+        let victim = dir.path().join("victim");
+        let destination = dir.path().join("destination");
+        fs::write(&victim, "unchanged").unwrap();
+        symlink(&victim, &destination).unwrap();
+
+        let error = Logger::write_private_file(&destination, b"replacement").unwrap_err();
+
+        assert_eq!(
+            (
+                error
+                    .downcast_ref::<std::io::Error>()
+                    .map(std::io::Error::kind),
+                fs::read_to_string(victim).unwrap(),
+            ),
+            (
+                Some(std::io::ErrorKind::AlreadyExists),
+                "unchanged".to_string()
+            )
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_unique_bundle_directory_is_private() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().unwrap();
+
+        let bundle = Logger::create_unique_bundle_directory(dir.path()).unwrap();
+
+        assert_eq!(
+            fs::metadata(bundle).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+    }
+
+    #[test]
+    fn create_unique_bundle_directory_uses_distinct_randomized_names() {
+        let dir = TempDir::new().unwrap();
+
+        let first = Logger::create_unique_bundle_directory(dir.path()).unwrap();
+        let second = Logger::create_unique_bundle_directory(dir.path()).unwrap();
+
+        assert_ne!(first.file_name(), second.file_name());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_redacted_log_creates_owner_only_destination() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().unwrap();
+        let source = dir.path().join("source.log");
+        let destination = dir.path().join("destination.log");
+        fs::write(&source, "contents").unwrap();
+
+        Logger::copy_redacted_log(&source, &destination, &[]).unwrap();
+
+        assert_eq!(
+            fs::metadata(destination).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_log_files_skips_symlinked_sources() {
+        use std::os::unix::fs::symlink;
+
+        let dir = TempDir::new().unwrap();
+        let log_dir = dir.path().join("logs");
+        let bundle_dir = dir.path().join("bundle");
+        fs::create_dir(&log_dir).unwrap();
+        fs::create_dir(&bundle_dir).unwrap();
+        let victim = dir.path().join("victim");
+        fs::write(&victim, "private contents").unwrap();
+        symlink(&victim, log_dir.join("hooklistener-linked.log")).unwrap();
+
+        Logger::copy_log_files(&log_dir, &bundle_dir, &[]).unwrap();
+
+        assert_eq!(fs::read_dir(bundle_dir).unwrap().count(), 0);
+    }
+
     #[test]
     fn invalid_config_cannot_be_copied_and_does_not_prevent_log_processing() {
         let dir = TempDir::new().unwrap();
@@ -612,7 +1038,7 @@ mod tests {
     }
 
     #[test]
-    fn failed_log_rename_removes_temporary_output() {
+    fn copy_redacted_log_refuses_existing_destination_without_temporary_output() {
         let dir = TempDir::new().unwrap();
         let source = dir.path().join("source.log");
         let destination = dir.path().join("destination.log");

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,10 @@ struct Cli {
     /// Output logs to stdout in addition to files (for debugging)
     #[arg(long)]
     log_stdout: bool,
+
+    /// Allow a non-loopback cleartext Hooklistener server (development only)
+    #[arg(long, global = true)]
+    allow_insecure_dev_server: bool,
 }
 
 #[derive(Subcommand)]
@@ -99,8 +103,8 @@ enum Commands {
         #[arg(short, long, default_value = "http://localhost:3000")]
         target: String,
 
-        /// WebSocket server URL (defaults to production)
-        #[arg(long)]
+        /// WebSocket server URL; requires wss except for approved development use
+        #[arg(long, value_name = "WSS_URL")]
         ws_url: Option<String>,
 
         /// Allow forwarding to a target that resolves outside loopback
@@ -988,11 +992,13 @@ fn emitted_at() -> String {
     Utc::now().to_rfc3339()
 }
 
-fn effective_listen_ws_url(ws_url: Option<&str>) -> String {
-    ws_url
+fn effective_listen_ws_url(ws_url: Option<&str>) -> Result<String> {
+    let ws_url = ws_url
         .map(str::to_string)
         .or_else(|| std::env::var("HOOKLISTENER_WS_URL").ok())
-        .unwrap_or_else(|| "wss://api.hooklistener.com".to_string())
+        .unwrap_or_else(|| "wss://api.hooklistener.com".to_string());
+    api::validate_websocket_base_url(&ws_url)?;
+    Ok(ws_url)
 }
 
 fn command_event_receipt(
@@ -1152,13 +1158,12 @@ fn endpoint_receipt_parts(
 fn listen_started_receipt(
     endpoint_slug: &str,
     target_url: &str,
-    ws_url: Option<&str>,
+    ws_url: &str,
     endpoint: Option<&api::DebugEndpointSummary>,
 ) -> serde_json::Value {
     let (endpoint_resource_uri, requests_resource_uri, endpoint_value) =
         endpoint_receipt_parts(endpoint_slug, endpoint);
     let session_resource_uri = listen_session_resource_uri(endpoint_slug);
-    let ws_url = effective_listen_ws_url(ws_url);
     let inspect_command = endpoint
         .map(|endpoint| format!("hooklistener endpoint requests {}", endpoint.id))
         .unwrap_or_else(|| "hooklistener endpoint list --json".to_string());
@@ -1627,6 +1632,9 @@ fn print_forward_request_preview(
 ) {
     let method = forward_method(method, request);
     let request_resource_uri = request_resource_uri(request_id);
+    let endpoint_id = sanitize_terminal(endpoint_id, TerminalTextLayout::Inline);
+    let organization_id = sanitize_terminal(organization_id, TerminalTextLayout::Inline);
+    let request_id = sanitize_terminal(request_id, TerminalTextLayout::Inline);
 
     print_status_block(
         OutputStatus::Info,
@@ -1634,10 +1642,19 @@ fn print_forward_request_preview(
         &[
             output_field("DRY RUN", "true"),
             output_field("WOULD CREATE", "debug_request_forward"),
-            output_field("TARGET URL", target_url.underlined()),
-            output_field("METHOD", method.bold()),
+            output_field(
+                "TARGET URL",
+                sanitize_terminal(target_url, TerminalTextLayout::Inline).underlined(),
+            ),
+            output_field(
+                "METHOD",
+                sanitize_terminal(&method, TerminalTextLayout::Inline).bold(),
+            ),
             output_field("REQUEST", request_id.dim()),
-            output_field("RESOURCE", request_resource_uri.dim()),
+            output_field(
+                "RESOURCE",
+                sanitize_terminal(&request_resource_uri, TerminalTextLayout::Inline).dim(),
+            ),
             output_field("ENDPOINT", endpoint_id.dim()),
             output_field("ORGANIZATION", organization_id.dim()),
             output_field(
@@ -1654,18 +1671,45 @@ fn print_forward_request_accepted(
     request_id: &str,
     response: &api::EndpointRequestForwardResponse,
 ) {
+    let forward_resource = forward_resource_uri(&response.forward_id);
+    let poll_command = forward_poll_command(&response.forward_id);
+
     print_status_block(
         OutputStatus::Ok,
         "FORWARD ACCEPTED",
         &[
-            output_field("FORWARD ID", response.forward_id.as_str().bold()),
-            output_field("STATUS", response.status.as_str().bold()),
-            output_field("TARGET URL", response.target_url.as_str().underlined()),
-            output_field("RESOURCE", forward_resource_uri(&response.forward_id).dim()),
-            output_field("POLL", forward_poll_command(&response.forward_id).dim()),
-            output_field("REQUEST", request_id.dim()),
-            output_field("ENDPOINT", endpoint_id.dim()),
-            output_field("ORGANIZATION", organization_id.dim()),
+            output_field(
+                "FORWARD ID",
+                sanitize_terminal(&response.forward_id, TerminalTextLayout::Inline).bold(),
+            ),
+            output_field(
+                "STATUS",
+                sanitize_terminal(&response.status, TerminalTextLayout::Inline).bold(),
+            ),
+            output_field(
+                "TARGET URL",
+                sanitize_terminal(&response.target_url, TerminalTextLayout::Inline).underlined(),
+            ),
+            output_field(
+                "RESOURCE",
+                sanitize_terminal(&forward_resource, TerminalTextLayout::Inline).dim(),
+            ),
+            output_field(
+                "POLL",
+                sanitize_terminal(&poll_command, TerminalTextLayout::Inline).dim(),
+            ),
+            output_field(
+                "REQUEST",
+                sanitize_terminal(request_id, TerminalTextLayout::Inline).dim(),
+            ),
+            output_field(
+                "ENDPOINT",
+                sanitize_terminal(endpoint_id, TerminalTextLayout::Inline).dim(),
+            ),
+            output_field(
+                "ORGANIZATION",
+                sanitize_terminal(organization_id, TerminalTextLayout::Inline).dim(),
+            ),
         ],
     );
 }
@@ -1840,7 +1884,7 @@ async fn run_listen_json(
     access_token_rx: watch::Receiver<String>,
     endpoint_slug: String,
     target_url: String,
-    ws_url: Option<String>,
+    ws_url: String,
     organization_id: Option<String>,
     allow_non_loopback: bool,
     insecure_tls: bool,
@@ -1854,7 +1898,7 @@ async fn run_listen_json(
     print_json_line(&listen_started_receipt(
         &endpoint_slug,
         &target_url,
-        ws_url.as_deref(),
+        &ws_url,
         endpoint.as_ref(),
     ))?;
 
@@ -1863,7 +1907,7 @@ async fn run_listen_json(
         access_token_rx,
         endpoint_slug.clone(),
         target,
-        ws_url,
+        Some(ws_url),
         event_tx,
     );
 
@@ -1994,6 +2038,7 @@ const SESSION_TOKEN_VALIDITY_DAYS: i64 = 60;
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
+    api::configure_server_url_security(cli.allow_insecure_dev_server);
     output::configure(cli.color, cli.json);
     let json = cli.json;
 
@@ -2012,6 +2057,7 @@ async fn run(cli: Cli) -> Result<()> {
         log_level,
         log_dir,
         log_stdout,
+        allow_insecure_dev_server: _,
     } = cli;
 
     let Some(command) = command else {
@@ -2061,6 +2107,7 @@ async fn run(cli: Cli) -> Result<()> {
             allow_non_loopback,
             insecure_tls,
         } => {
+            let ws_url = effective_listen_ws_url(ws_url.as_deref())?;
             // Initialize logging for tunnel
             let log_config = LogConfig {
                 level: log_level.clone(),
@@ -2112,7 +2159,7 @@ async fn run(cli: Cli) -> Result<()> {
                     access_token_rx,
                     endpoint.clone(),
                     target_policy,
-                    ws_url,
+                    Some(ws_url),
                     event_tx,
                 );
 
@@ -3762,8 +3809,14 @@ fn print_tunnel_lifecycle_resource<T: serde::Serialize>(
             &format!("TUNNEL {}", operation.to_uppercase()),
         );
         println!();
-        print_field("RESOURCE", &resource_uri);
-        print_field("ORGANIZATION", organization_id);
+        print_field(
+            "RESOURCE",
+            sanitize_terminal(&resource_uri, TerminalTextLayout::Inline),
+        );
+        print_field(
+            "ORGANIZATION",
+            sanitize_terminal(organization_id, TerminalTextLayout::Inline),
+        );
         print_json(resource)
     }
 }
@@ -3781,22 +3834,35 @@ fn print_tunnel_sessions(sessions: &[api::TunnelSessionResource], organization_i
     let mut table = new_table(&["ID", "Status", "Slug", "Mode", "Updated"]);
     for session in sessions {
         table.add_row(vec![
-            session.id.clone(),
-            session.status.clone(),
+            sanitize_terminal_display(&session.id),
+            sanitize_terminal_display(&session.status),
             session
                 .route
                 .as_ref()
-                .map(|route| route.slug.clone())
+                .map(|route| sanitize_terminal_display(&route.slug))
                 .unwrap_or_else(|| "-".to_string()),
             session
                 .route
                 .as_ref()
-                .map(|route| route.mode.clone())
+                .map(|route| sanitize_terminal_display(&route.mode))
                 .unwrap_or_else(|| "-".to_string()),
-            session.updated_at.clone(),
+            sanitize_terminal_display(&session.updated_at),
         ]);
     }
     println!("{table}");
+}
+
+fn format_tunnel_lifecycle_event(event: &api::TunnelLifecycleEvent) -> String {
+    format!(
+        "{}  {}  capture={}  attempt={}",
+        event.position,
+        sanitize_terminal(&event.event_type, TerminalTextLayout::Inline),
+        sanitize_terminal(&event.capture_id, TerminalTextLayout::Inline),
+        sanitize_terminal(
+            event.delivery_id.as_deref().unwrap_or("-"),
+            TerminalTextLayout::Inline,
+        )
+    )
 }
 
 async fn run_tunnel_lifecycle_events(
@@ -3819,13 +3885,7 @@ async fn run_tunnel_lifecycle_events(
             if json {
                 print_json_line(&tunnel_lifecycle_event_envelope(event))?;
             } else {
-                println!(
-                    "{}  {}  capture={}  attempt={}",
-                    event.position,
-                    event.event_type,
-                    event.capture_id,
-                    event.delivery_id.as_deref().unwrap_or("-")
-                );
+                println!("{}", format_tunnel_lifecycle_event(event));
             }
         }
 
@@ -3906,7 +3966,7 @@ async fn run_login_flow(force_reauth: bool) -> Result<()> {
         config.save()?;
     }
 
-    let mut device_flow = auth::DeviceCodeFlow::new(api::default_base_url());
+    let mut device_flow = auth::DeviceCodeFlow::new(api::default_base_url()?);
 
     let user_code = device_flow.initiate_device_flow().await?;
     let display_code = device_flow
@@ -3929,9 +3989,6 @@ async fn run_login_flow(force_reauth: bool) -> Result<()> {
     let spinner_chars = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧"];
     let mut spinner_idx: usize = 0;
     let mut stdout = io::stdout();
-
-    let mut poll_interval = tokio::time::interval(Duration::from_secs(5));
-    poll_interval.tick().await; // consume the immediate first tick
 
     loop {
         // Poll the API
@@ -3980,8 +4037,25 @@ async fn run_login_flow(force_reauth: bool) -> Result<()> {
             }
         }
 
-        // Animate spinner until next poll
+        let poll_delay = device_flow.time_until_next_poll();
+        if poll_delay.is_zero() {
+            continue;
+        }
+        let next_poll = tokio::time::sleep(poll_delay);
+        tokio::pin!(next_poll);
+
+        // Animate spinner until the server-authorized next poll.
         loop {
+            if device_flow
+                .time_remaining()
+                .is_some_and(|remaining| remaining == ChronoDuration::zero())
+            {
+                execute!(stdout, MoveToColumn(0), Clear(ClearType::CurrentLine))?;
+                return Err(anyhow!(
+                    "Device code expired before authorization completed. Please run `hooklistener login` again."
+                ));
+            }
+
             let spinner = spinner_chars[spinner_idx % spinner_chars.len()];
             spinner_idx = (spinner_idx + 1) % spinner_chars.len();
 
@@ -4004,7 +4078,7 @@ async fn run_login_flow(force_reauth: bool) -> Result<()> {
 
             tokio::select! {
                 _ = sleep(Duration::from_millis(80)) => continue,
-                _ = poll_interval.tick() => break,
+                _ = &mut next_poll => break,
             }
         }
     }
@@ -4036,7 +4110,13 @@ fn refreshed_access_token_rx(
 }
 
 async fn refresh_access_token_loop(config: config::Config, token_tx: watch::Sender<String>) {
-    let base_url = api::default_base_url();
+    let base_url = match api::default_base_url() {
+        Ok(base_url) => base_url,
+        Err(error) => {
+            error!(%error, "Access-token refresh disabled by invalid API URL");
+            return;
+        }
+    };
     refresh_access_token_loop_with(config, token_tx, &base_url).await;
 }
 
@@ -4132,7 +4212,8 @@ async fn ensure_valid_token(config: &mut config::Config) -> Result<String> {
 }
 
 async fn refresh_access_token_from_config(config: &mut config::Config) -> Result<String> {
-    refresh_access_token_from_config_with(config, &api::default_base_url(), None).await
+    let base_url = api::default_base_url()?;
+    refresh_access_token_from_config_with(config, &base_url, None).await
 }
 
 async fn refresh_access_token_from_config_with(
@@ -4409,12 +4490,79 @@ fn print_section(label: &str) {
 
 /// Print a dim context line like "ORGANIZATION abc123".
 fn print_context(label: &str, value: &str) {
-    println!("{} {}", output_label(label).dim(), value.dim());
+    println!(
+        "{} {}",
+        output_label(label).dim(),
+        sanitize_terminal(value, TerminalTextLayout::Inline).dim()
+    );
 }
 
 /// Print a pagination footer.
 fn print_pagination(p: &api::Pagination) {
     println!("{}", format_pagination_line(p).dim());
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TerminalTextLayout {
+    Inline,
+    Block,
+}
+
+/// Escape terminal control characters while retaining readable, inert text.
+///
+/// Inline values escape every control character so untrusted input cannot move
+/// the cursor or forge additional output. Block values additionally retain LF
+/// and tab for payload readability; all other C0, DEL, and C1 controls remain
+/// escaped, including ESC, BEL, CR, and the 8-bit OSC/CSI introducers.
+fn sanitize_terminal(value: &str, layout: TerminalTextLayout) -> std::borrow::Cow<'_, str> {
+    let should_escape = |character: char| {
+        character.is_control()
+            && !(layout == TerminalTextLayout::Block && matches!(character, '\n' | '\t'))
+    };
+
+    if !value.chars().any(should_escape) {
+        return std::borrow::Cow::Borrowed(value);
+    }
+
+    let mut sanitized = String::with_capacity(value.len());
+    for character in value.chars() {
+        if should_escape(character) {
+            sanitized.extend(character.escape_default());
+        } else {
+            sanitized.push(character);
+        }
+    }
+    std::borrow::Cow::Owned(sanitized)
+}
+
+fn sanitize_terminal_display(value: impl std::fmt::Display) -> String {
+    let value = value.to_string();
+    sanitize_terminal(&value, TerminalTextLayout::Inline).into_owned()
+}
+
+fn truncate_terminal_inline(value: &str, max_chars: usize) -> String {
+    if max_chars == 0 {
+        return String::new();
+    }
+
+    let sanitized = sanitize_terminal(value, TerminalTextLayout::Inline);
+    if sanitized.chars().count() <= max_chars {
+        return sanitized.into_owned();
+    }
+
+    let prefix = sanitized
+        .chars()
+        .take(max_chars.saturating_sub(1))
+        .collect::<String>();
+    format!("{prefix}…")
+}
+
+fn format_terminal_body(body: &str) -> String {
+    sanitize_terminal(body, TerminalTextLayout::Block)
+        .split('\n')
+        .map(|line| format!("│ {line}"))
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// Print a key-value map (headers, query params) with a bold section label.
@@ -4428,7 +4576,13 @@ fn print_key_value_map(
     } else {
         print_section(label);
         for (key, value) in map {
-            println!("  {}{}{}", key.as_str().dim(), separator, value);
+            let value = value.to_string();
+            println!(
+                "  {}{}{}",
+                sanitize_terminal(key, TerminalTextLayout::Inline).dim(),
+                separator,
+                sanitize_terminal(&value, TerminalTextLayout::Inline)
+            );
         }
     }
 }
@@ -4438,7 +4592,7 @@ fn print_body_section(label: &str, body: Option<&str>) {
     match body {
         Some(body) if !body.is_empty() => {
             print_section(label);
-            println!("{}", body);
+            println!("{}", format_terminal_body(body));
         }
         _ => print_field(label, "(empty)".dim()),
     }
@@ -4492,24 +4646,42 @@ fn print_endpoints(endpoints: &[api::DebugEndpointSummary]) {
     let mut table = new_table(&["ID", "Slug", "Status", "Webhook URL", "Name"]);
     for endpoint in endpoints {
         table.add_row(vec![
-            &endpoint.id,
-            &endpoint.slug,
-            &endpoint.status,
-            &endpoint.webhook_url,
-            &endpoint.name,
+            sanitize_terminal(&endpoint.id, TerminalTextLayout::Inline).into_owned(),
+            sanitize_terminal(&endpoint.slug, TerminalTextLayout::Inline).into_owned(),
+            sanitize_terminal(&endpoint.status, TerminalTextLayout::Inline).into_owned(),
+            sanitize_terminal(&endpoint.webhook_url, TerminalTextLayout::Inline).into_owned(),
+            sanitize_terminal(&endpoint.name, TerminalTextLayout::Inline).into_owned(),
         ]);
     }
     println!("{table}");
 }
 
 fn print_endpoint_detail(endpoint: &api::DebugEndpointSummary) {
-    print_field("ID", &endpoint.id);
-    print_field("SLUG", &endpoint.slug);
-    print_field("STATUS", &endpoint.status);
-    print_field("WEBHOOK URL", endpoint.webhook_url.as_str().underlined());
-    print_field("NAME", &endpoint.name);
+    print_field(
+        "ID",
+        sanitize_terminal(&endpoint.id, TerminalTextLayout::Inline),
+    );
+    print_field(
+        "SLUG",
+        sanitize_terminal(&endpoint.slug, TerminalTextLayout::Inline),
+    );
+    print_field(
+        "STATUS",
+        sanitize_terminal(&endpoint.status, TerminalTextLayout::Inline),
+    );
+    print_field(
+        "WEBHOOK URL",
+        sanitize_terminal(&endpoint.webhook_url, TerminalTextLayout::Inline).underlined(),
+    );
+    print_field(
+        "NAME",
+        sanitize_terminal(&endpoint.name, TerminalTextLayout::Inline),
+    );
     if let Some(created_at) = endpoint.created_at.as_deref() {
-        print_field("CREATED AT", created_at.dim());
+        print_field(
+            "CREATED AT",
+            sanitize_terminal(created_at, TerminalTextLayout::Inline).dim(),
+        );
     }
 }
 
@@ -4525,10 +4697,10 @@ fn print_endpoint_requests(response: &api::EndpointRequestsResponse) {
     let mut table = new_table(&["ID", "Method", "URL", "Remote"]);
     for request in &response.data {
         table.add_row(vec![
-            &request.id,
-            &request.method,
-            &request.url,
-            &request.remote_addr,
+            sanitize_terminal(&request.id, TerminalTextLayout::Inline).into_owned(),
+            sanitize_terminal(&request.method, TerminalTextLayout::Inline).into_owned(),
+            sanitize_terminal(&request.url, TerminalTextLayout::Inline).into_owned(),
+            sanitize_terminal(&request.remote_addr, TerminalTextLayout::Inline).into_owned(),
         ]);
     }
     println!("{table}");
@@ -4536,21 +4708,36 @@ fn print_endpoint_requests(response: &api::EndpointRequestsResponse) {
 }
 
 fn print_endpoint_request_detail(request: &api::DebugRequestDetail) {
-    print_field("REQUEST ID", &request.id);
-    print_field("METHOD", request.method.as_str().bold());
+    print_field(
+        "REQUEST ID",
+        sanitize_terminal(&request.id, TerminalTextLayout::Inline),
+    );
+    print_field(
+        "METHOD",
+        sanitize_terminal(&request.method, TerminalTextLayout::Inline).bold(),
+    );
     if let Some(path) = request.path.as_deref() {
-        print_field("PATH", path);
+        print_field("PATH", sanitize_terminal(path, TerminalTextLayout::Inline));
     }
-    print_field("URL", &request.url);
+    print_field(
+        "URL",
+        sanitize_terminal(&request.url, TerminalTextLayout::Inline),
+    );
 
     if let Some(status_remote) = request.remote_addr.as_deref() {
-        print_field("REMOTE", status_remote);
+        print_field(
+            "REMOTE",
+            sanitize_terminal(status_remote, TerminalTextLayout::Inline),
+        );
     }
     if let Some(content_length) = request.content_length {
         print_field("CONTENT LEN", content_length);
     }
     if let Some(created_at) = request.created_at.as_deref() {
-        print_field("CREATED AT", created_at.dim());
+        print_field(
+            "CREATED AT",
+            sanitize_terminal(created_at, TerminalTextLayout::Inline).dim(),
+        );
     }
 
     println!();
@@ -4586,15 +4773,19 @@ fn print_endpoint_request_forwards(response: &api::EndpointRequestForwardsRespon
             .map(|ms| format!("{ms}ms"))
             .unwrap_or_else(|| "-".into());
         let target = match forward.error_message.as_deref() {
-            Some(err) => format!("{}\n  [ERR] {err}", forward.target_url),
-            None => forward.target_url.clone(),
+            Some(err) => format!(
+                "{}\n  [ERR] {}",
+                sanitize_terminal(&forward.target_url, TerminalTextLayout::Inline),
+                sanitize_terminal(err, TerminalTextLayout::Inline)
+            ),
+            None => sanitize_terminal(&forward.target_url, TerminalTextLayout::Inline).into_owned(),
         };
         table.add_row(vec![
-            forward.id.as_str(),
-            &forward.method,
-            &status,
-            &duration,
-            &target,
+            sanitize_terminal(&forward.id, TerminalTextLayout::Inline).into_owned(),
+            sanitize_terminal(&forward.method, TerminalTextLayout::Inline).into_owned(),
+            status,
+            duration,
+            target,
         ]);
     }
     println!("{table}");
@@ -4602,10 +4793,22 @@ fn print_endpoint_request_forwards(response: &api::EndpointRequestForwardsRespon
 }
 
 fn print_forward_detail(forward: &api::DebugRequestForwardDetail) {
-    print_field("FORWARD ID", &forward.id);
-    print_field("REQUEST ID", &forward.debug_request_id);
-    print_field("TARGET URL", &forward.target_url);
-    print_field("METHOD", forward.method.as_str().bold());
+    print_field(
+        "FORWARD ID",
+        sanitize_terminal(&forward.id, TerminalTextLayout::Inline),
+    );
+    print_field(
+        "REQUEST ID",
+        sanitize_terminal(&forward.debug_request_id, TerminalTextLayout::Inline),
+    );
+    print_field(
+        "TARGET URL",
+        sanitize_terminal(&forward.target_url, TerminalTextLayout::Inline),
+    );
+    print_field(
+        "METHOD",
+        sanitize_terminal(&forward.method, TerminalTextLayout::Inline).bold(),
+    );
     if let Some(status_code) = forward.status_code {
         print_field("STATUS", style_status_code(status_code));
     } else {
@@ -4615,10 +4818,16 @@ fn print_forward_detail(forward: &api::DebugRequestForwardDetail) {
         print_field("DURATION", format!("{duration_ms}ms"));
     }
     if let Some(attempted_at) = forward.attempted_at.as_deref() {
-        print_field("ATTEMPTED AT", attempted_at.dim());
+        print_field(
+            "ATTEMPTED AT",
+            sanitize_terminal(attempted_at, TerminalTextLayout::Inline).dim(),
+        );
     }
     if let Some(error_message) = forward.error_message.as_deref() {
-        print_field("ERROR", error_message);
+        print_field(
+            "ERROR",
+            sanitize_terminal(error_message, TerminalTextLayout::Inline),
+        );
     }
 
     println!();
@@ -4658,17 +4867,41 @@ fn print_case_run_result(result: &api::CaseRunResult) {
     print_status(status, "CASE RUN");
     println!();
     if let Some(run_id) = result.case_suite_run_id.as_deref().or(result.id.as_deref()) {
-        print_field("RUN ID", run_id);
+        print_field(
+            "RUN ID",
+            sanitize_terminal(run_id, TerminalTextLayout::Inline),
+        );
     }
     if let Some(report_url) = result.case_suite_run_url.as_deref() {
-        print_field("REPORT", report_url);
+        print_field(
+            "REPORT",
+            sanitize_terminal(report_url, TerminalTextLayout::Inline),
+        );
     }
-    print_field("RESULT", result.result_status.as_str().bold());
-    print_field("STATUS", &result.status);
-    print_field("ENDPOINT", &result.endpoint_id);
-    print_field("TARGET", case_run_target_label(&result.target));
+    print_field(
+        "RESULT",
+        sanitize_terminal(&result.result_status, TerminalTextLayout::Inline).bold(),
+    );
+    print_field(
+        "STATUS",
+        sanitize_terminal(&result.status, TerminalTextLayout::Inline),
+    );
+    print_field(
+        "ENDPOINT",
+        sanitize_terminal(&result.endpoint_id, TerminalTextLayout::Inline),
+    );
+    print_field(
+        "TARGET",
+        sanitize_terminal(
+            &case_run_target_label(&result.target),
+            TerminalTextLayout::Inline,
+        ),
+    );
     if let Some(source) = result.source.as_deref() {
-        print_field("SOURCE", source.to_uppercase());
+        print_field(
+            "SOURCE",
+            sanitize_terminal(&source.to_uppercase(), TerminalTextLayout::Inline),
+        );
     }
     print_field("ASYNC", yes_no(result.async_run));
     if let Some(waited) = result.waited {
@@ -4749,13 +4982,13 @@ fn print_case_run_result(result: &api::CaseRunResult) {
                 .or_else(|| forward.poll_url.clone())
                 .unwrap_or_else(|| "-".to_string());
             table.add_row(vec![
-                forward.id.as_str().to_string(),
-                forward.debug_request_id.clone(),
-                value_or_dash(forward.debug_request_case_id.as_deref()).to_string(),
-                case_run_forward_target(forward),
+                sanitize_terminal_display(&forward.id),
+                sanitize_terminal_display(&forward.debug_request_id),
+                sanitize_terminal_display(value_or_dash(forward.debug_request_case_id.as_deref())),
+                sanitize_terminal_display(case_run_forward_target(forward)),
                 status,
-                assertion,
-                error,
+                sanitize_terminal_display(assertion),
+                sanitize_terminal_display(error),
             ]);
         }
         println!("{table}");
@@ -4767,8 +5000,8 @@ fn print_case_run_result(result: &api::CaseRunResult) {
         let mut table = new_table(&["Case", "Reason"]);
         for failure in &result.failures {
             table.add_row(vec![
-                failure.case_id.as_str().to_string(),
-                case_run_failure_reason(failure),
+                sanitize_terminal_display(&failure.case_id),
+                sanitize_terminal_display(case_run_failure_reason(failure)),
             ]);
         }
         println!("{table}");
@@ -4785,7 +5018,11 @@ fn print_static_tunnels(response: &api::StaticTunnelsResponse) {
         let mut table = new_table(&["ID", "Slug", "Name"]);
         for tunnel in &response.static_tunnels {
             let name = tunnel.name.as_deref().unwrap_or("");
-            table.add_row(vec![tunnel.id.as_str(), &tunnel.slug, name]);
+            table.add_row(vec![
+                sanitize_terminal_display(&tunnel.id),
+                sanitize_terminal_display(&tunnel.slug),
+                sanitize_terminal_display(name),
+            ]);
         }
         println!("{table}");
     }
@@ -4806,9 +5043,13 @@ fn print_anon_events(response: &api::AnonEventsResponse) {
         let mut table = new_table(&["ID", "Method", "Received At"]);
         for event in &response.data {
             table.add_row(vec![
-                event.id.as_str(),
-                event.method.as_str(),
-                value_or_dash(event.inserted_at.as_deref()),
+                sanitize_terminal(&event.id, TerminalTextLayout::Inline).into_owned(),
+                sanitize_terminal(&event.method, TerminalTextLayout::Inline).into_owned(),
+                sanitize_terminal(
+                    value_or_dash(event.inserted_at.as_deref()),
+                    TerminalTextLayout::Inline,
+                )
+                .into_owned(),
             ]);
         }
         println!("{table}");
@@ -4817,14 +5058,29 @@ fn print_anon_events(response: &api::AnonEventsResponse) {
 }
 
 fn print_anon_event_detail(event: &api::AnonEvent) {
-    print_field("EVENT ID", &event.id);
-    print_field("ENDPOINT ID", &event.endpoint_id);
-    print_field("METHOD", event.method.as_str().bold());
+    print_field(
+        "EVENT ID",
+        sanitize_terminal(&event.id, TerminalTextLayout::Inline),
+    );
+    print_field(
+        "ENDPOINT ID",
+        sanitize_terminal(&event.endpoint_id, TerminalTextLayout::Inline),
+    );
+    print_field(
+        "METHOD",
+        sanitize_terminal(&event.method, TerminalTextLayout::Inline).bold(),
+    );
     if let Some(status) = event.status.as_deref() {
-        print_field("STATUS", status);
+        print_field(
+            "STATUS",
+            sanitize_terminal(status, TerminalTextLayout::Inline),
+        );
     }
     if let Some(inserted_at) = event.inserted_at.as_deref() {
-        print_field("RECEIVED AT", inserted_at.dim());
+        print_field(
+            "RECEIVED AT",
+            sanitize_terminal(inserted_at, TerminalTextLayout::Inline).dim(),
+        );
     }
 
     println!();
@@ -4846,12 +5102,16 @@ fn print_shared_requests(shares: &[api::SharedRequestSummary]) {
     let mut table = new_table(&["ID", "Token", "Fwds", "Views", "Protected", "Expires At"]);
     for share in shares {
         table.add_row(vec![
-            share.id.as_str().to_string(),
-            share.share_token.clone(),
+            sanitize_terminal(&share.id, TerminalTextLayout::Inline).into_owned(),
+            sanitize_terminal(&share.share_token, TerminalTextLayout::Inline).into_owned(),
             yes_no(share.include_forwards).to_string(),
             share.view_count.to_string(),
             yes_no(share.password_protected).to_string(),
-            value_or_dash(share.expires_at.as_deref()).to_string(),
+            sanitize_terminal(
+                value_or_dash(share.expires_at.as_deref()),
+                TerminalTextLayout::Inline,
+            )
+            .into_owned(),
         ]);
     }
     println!("{table}");
@@ -4859,10 +5119,16 @@ fn print_shared_requests(shares: &[api::SharedRequestSummary]) {
 
 fn print_shared_request_full(data: &serde_json::Value) {
     if let Some(token) = data.get("share_token").and_then(|v| v.as_str()) {
-        print_field("SHARE TOKEN", token);
+        print_field(
+            "SHARE TOKEN",
+            sanitize_terminal(token, TerminalTextLayout::Inline),
+        );
     }
     if let Some(expires) = data.get("expires_at").and_then(|v| v.as_str()) {
-        print_field("EXPIRES AT", expires.dim());
+        print_field(
+            "EXPIRES AT",
+            sanitize_terminal(expires, TerminalTextLayout::Inline).dim(),
+        );
     }
     if let Some(views) = data.get("view_count").and_then(|v| v.as_u64()) {
         print_field("VIEWS", views);
@@ -4872,19 +5138,28 @@ fn print_shared_request_full(data: &serde_json::Value) {
         println!();
         print_section("DEBUG REQUEST");
         if let Some(id) = request.get("id").and_then(|v| v.as_str()) {
-            print_field("ID", id);
+            print_field("ID", sanitize_terminal(id, TerminalTextLayout::Inline));
         }
         if let Some(method) = request.get("method").and_then(|v| v.as_str()) {
-            print_field("METHOD", method.bold());
+            print_field(
+                "METHOD",
+                sanitize_terminal(method, TerminalTextLayout::Inline).bold(),
+            );
         }
         if let Some(url) = request.get("url").and_then(|v| v.as_str()) {
-            print_field("URL", url);
+            print_field("URL", sanitize_terminal(url, TerminalTextLayout::Inline));
         }
         if let Some(remote) = request.get("remote_addr").and_then(|v| v.as_str()) {
-            print_field("REMOTE", remote.dim());
+            print_field(
+                "REMOTE",
+                sanitize_terminal(remote, TerminalTextLayout::Inline).dim(),
+            );
         }
         if let Some(created) = request.get("created_at").and_then(|v| v.as_str()) {
-            print_field("CREATED AT", created.dim());
+            print_field(
+                "CREATED AT",
+                sanitize_terminal(created, TerminalTextLayout::Inline).dim(),
+            );
         }
 
         if let Some(headers) = request.get("headers").and_then(|v| v.as_object())
@@ -4893,7 +5168,12 @@ fn print_shared_request_full(data: &serde_json::Value) {
             println!();
             print_section("HEADERS");
             for (key, value) in headers {
-                println!("  {}: {}", key.as_str().dim(), value);
+                let value = value.to_string();
+                println!(
+                    "  {}: {}",
+                    sanitize_terminal(key, TerminalTextLayout::Inline).dim(),
+                    sanitize_terminal(&value, TerminalTextLayout::Inline)
+                );
             }
         }
 
@@ -4905,8 +5185,7 @@ fn print_shared_request_full(data: &serde_json::Value) {
             && !body.is_empty()
         {
             println!();
-            print_section("BODY");
-            println!("{}", body);
+            print_body_section("BODY", Some(body));
         }
     }
 
@@ -4931,7 +5210,13 @@ fn print_shared_request_full(data: &serde_json::Value) {
                 .and_then(|v| v.as_u64())
                 .map(|ms| format!("{}ms", ms))
                 .unwrap_or_else(|| "-".to_string());
-            println!("  {} {} → {} ({})", method.bold(), status, target, duration);
+            println!(
+                "  {} {} → {} ({})",
+                sanitize_terminal(method, TerminalTextLayout::Inline).bold(),
+                status,
+                sanitize_terminal(target, TerminalTextLayout::Inline),
+                duration
+            );
         }
     }
 }
@@ -4944,7 +5229,9 @@ fn style_monitor_status(status: Option<&str>) -> String {
     match monitor_status_label(status) {
         "up" => "up".green().to_string(),
         "down" => "down".red().to_string(),
-        s => s.yellow().to_string(),
+        status => sanitize_terminal(status, TerminalTextLayout::Inline)
+            .yellow()
+            .to_string(),
     }
 }
 
@@ -4964,20 +5251,17 @@ fn print_monitors(monitors: &[api::UptimeMonitor]) {
             .check_interval
             .map(|i| format!("{}m", i))
             .unwrap_or_default();
-        let url_display = if m.url.len() > 24 {
-            format!("{}…", &m.url[..23])
-        } else {
-            m.url.clone()
-        };
+        let url_display = truncate_terminal_inline(&m.url, 24);
+        let sanitized_name = sanitize_terminal(&m.name, TerminalTextLayout::Inline);
         let name = if m.enabled {
-            m.name.clone()
+            sanitized_name.into_owned()
         } else {
-            format!("{} (disabled)", m.name)
+            format!("{sanitized_name} (disabled)")
         };
         table.add_row(vec![
-            m.id.clone(),
-            status.to_string(),
-            m.method.to_uppercase(),
+            sanitize_terminal_display(&m.id),
+            sanitize_terminal_display(status),
+            sanitize_terminal_display(m.method.to_uppercase()),
             interval,
             url_display,
             name,
@@ -4987,10 +5271,19 @@ fn print_monitors(monitors: &[api::UptimeMonitor]) {
 }
 
 fn print_monitor_detail(m: &api::UptimeMonitor) {
-    print_field("ID", &m.id);
-    print_field("NAME", &m.name);
-    print_field("URL", m.url.as_str().underlined());
-    print_field("METHOD", m.method.to_uppercase().bold());
+    print_field("ID", sanitize_terminal(&m.id, TerminalTextLayout::Inline));
+    print_field(
+        "NAME",
+        sanitize_terminal(&m.name, TerminalTextLayout::Inline),
+    );
+    print_field(
+        "URL",
+        sanitize_terminal(&m.url, TerminalTextLayout::Inline).underlined(),
+    );
+    print_field(
+        "METHOD",
+        sanitize_terminal(&m.method.to_uppercase(), TerminalTextLayout::Inline).bold(),
+    );
 
     let status = style_monitor_status(m.current_status.as_deref());
     let enabled = if m.enabled {
@@ -5005,7 +5298,10 @@ fn print_monitor_detail(m: &api::UptimeMonitor) {
         print_field("EXPECTED", code);
     }
     if let Some(ref bc) = m.body_contains {
-        print_field("BODY MATCH", bc);
+        print_field(
+            "BODY MATCH",
+            sanitize_terminal(bc, TerminalTextLayout::Inline),
+        );
     }
     if let Some(interval) = m.check_interval {
         print_field("INTERVAL", format!("{interval}m"));
@@ -5027,13 +5323,22 @@ fn print_monitor_detail(m: &api::UptimeMonitor) {
     );
 
     if let Some(ref checked) = m.last_checked_at {
-        print_field("LAST CHECK", checked.as_str().dim());
+        print_field(
+            "LAST CHECK",
+            sanitize_terminal(checked, TerminalTextLayout::Inline).dim(),
+        );
     }
     if let Some(ref changed) = m.last_status_change_at {
-        print_field("STATUS CHANGE", changed.as_str().dim());
+        print_field(
+            "STATUS CHANGE",
+            sanitize_terminal(changed, TerminalTextLayout::Inline).dim(),
+        );
     }
     if let Some(ref created) = m.created_at {
-        print_field("CREATED AT", created.as_str().dim());
+        print_field(
+            "CREATED AT",
+            sanitize_terminal(created, TerminalTextLayout::Inline).dim(),
+        );
     }
 }
 
@@ -5086,12 +5391,12 @@ fn print_uptime_checks(response: &api::UptimeChecksResponse) {
             let error = value_or_dash(check.error_message.as_deref());
 
             table.add_row(vec![
-                check.id.clone(),
-                check.status.clone(),
+                sanitize_terminal_display(&check.id),
+                sanitize_terminal_display(&check.status),
                 code,
                 rt,
-                checked.to_string(),
-                error.to_string(),
+                sanitize_terminal_display(checked),
+                sanitize_terminal_display(error),
             ]);
         }
         println!("{table}");
@@ -5600,12 +5905,12 @@ fn display_error(err: &anyhow::Error, json: bool) {
 
     eprint_status(OutputStatus::Err, "COMMAND FAILED");
     eprintln!();
-    eprint_field("MESSAGE", err);
+    eprint_field("MESSAGE", sanitize_terminal_display(err));
     if let Some(hint) = error_hint(err) {
-        eprint_field("HINT", hint);
+        eprint_field("HINT", sanitize_terminal_display(hint));
     }
     for cause in err.chain().skip(1) {
-        eprint_field("CAUSE", cause);
+        eprint_field("CAUSE", sanitize_terminal_display(cause));
     }
 }
 
@@ -5685,6 +5990,128 @@ mod tests {
         assert!(
             !output.contains("\u{1b}["),
             "output contains ANSI escape sequences: {output:?}"
+        );
+    }
+
+    #[test]
+    fn sanitize_terminal_escapes_ansi_csi_and_c1_csi_introducers() {
+        let input = "before\u{1b}[31mred\u{1b}[0m\u{9b}2Jafter";
+
+        assert_eq!(
+            sanitize_terminal(input, TerminalTextLayout::Inline),
+            r"before\u{1b}[31mred\u{1b}[0m\u{9b}2Jafter"
+        );
+    }
+
+    #[test]
+    fn sanitize_terminal_inline_neutralizes_every_c0_del_and_c1_control() {
+        let input = (0..=0x9f).filter_map(char::from_u32).collect::<String>();
+        let sanitized = sanitize_terminal(&input, TerminalTextLayout::Inline);
+
+        assert!(!sanitized.chars().any(char::is_control));
+    }
+
+    #[test]
+    fn sanitize_terminal_escapes_osc_52_with_bel_terminator() {
+        let input = "\u{1b}]52;c;SGVsbG8=\u{7}";
+
+        assert_eq!(
+            sanitize_terminal(input, TerminalTextLayout::Inline),
+            r"\u{1b}]52;c;SGVsbG8=\u{7}"
+        );
+    }
+
+    #[test]
+    fn sanitize_terminal_escapes_osc_8_with_st_terminator() {
+        let input = "\u{1b}]8;;https://evil.example\u{1b}\\click\u{1b}]8;;\u{1b}\\";
+
+        assert_eq!(
+            sanitize_terminal(input, TerminalTextLayout::Inline),
+            r"\u{1b}]8;;https://evil.example\u{1b}\click\u{1b}]8;;\u{1b}\"
+        );
+    }
+
+    #[test]
+    fn sanitize_terminal_escapes_carriage_return_backspace_and_inline_layout() {
+        let input = "legitimate\r[OK] forged\u{8}!\n\tnext";
+
+        assert_eq!(
+            sanitize_terminal(input, TerminalTextLayout::Inline),
+            r"legitimate\r[OK] forged\u{8}!\n\tnext"
+        );
+    }
+
+    #[test]
+    fn sanitize_terminal_block_layout_preserves_only_newline_and_tab_controls() {
+        let input = "line one\n\tline two\rrewritten\u{7}";
+
+        assert_eq!(
+            sanitize_terminal(input, TerminalTextLayout::Block),
+            "line one\n\tline two\\rrewritten\\u{7}"
+        );
+    }
+
+    #[test]
+    fn sanitize_terminal_borrows_benign_unicode_text_unchanged() {
+        let input = "Café 東京 — webhook payload";
+        let sanitized = sanitize_terminal(input, TerminalTextLayout::Inline);
+
+        assert!(matches!(sanitized, std::borrow::Cow::Borrowed(value) if value == input));
+    }
+
+    #[test]
+    fn format_terminal_body_gutters_forged_status_and_blank_trailing_lines() {
+        let body = "legitimate\n\n[OK] forged\n";
+
+        assert_eq!(
+            format_terminal_body(body),
+            "│ legitimate\n│ \n│ [OK] forged\n│ "
+        );
+    }
+
+    #[test]
+    fn sanitize_terminal_display_neutralizes_server_error_controls_and_newlines() {
+        let error = anyhow!("upstream \u{1b}[31mfailed\u{1b}[0m\n[OK] forged\r");
+
+        assert_eq!(
+            sanitize_terminal_display(&error),
+            r"upstream \u{1b}[31mfailed\u{1b}[0m\n[OK] forged\r"
+        );
+    }
+
+    #[test]
+    fn tunnel_lifecycle_event_output_neutralizes_every_remote_text_field() {
+        let event = api::TunnelLifecycleEvent {
+            id: "event-id".to_string(),
+            position: 7,
+            cursor: "cursor".to_string(),
+            organization_id: "organization".to_string(),
+            capture_id: "capture\rforged".to_string(),
+            delivery_id: Some("delivery\u{9b}2J".to_string()),
+            sequence: 1,
+            fence: None,
+            event_type: "opened\n[OK]\u{1b}]52;c;x\u{7}".to_string(),
+            metadata: serde_json::json!({}),
+            created_at: "2026-07-20T00:00:00Z".to_string(),
+        };
+
+        assert_eq!(
+            format_tunnel_lifecycle_event(&event),
+            r"7  opened\n[OK]\u{1b}]52;c;x\u{7}  capture=capture\rforged  attempt=delivery\u{9b}2J"
+        );
+    }
+
+    #[test]
+    fn monitor_output_neutralizes_status_controls_and_truncates_unicode_safely() {
+        let styled = style_monitor_status(Some("pending\n[OK]\u{1b}]52;c;x\u{7}"));
+
+        assert!(!styled.contains('\n'));
+        assert!(!styled.contains("\u{1b}]52"));
+        assert!(styled.contains(r"pending\n[OK]\u{1b}]52;c;x\u{7}"));
+        assert_eq!(truncate_terminal_inline("東京 webhook", 4), "東京 …");
+        assert_eq!(
+            truncate_terminal_inline("\u{1b}]52;c;x\u{7}", 64),
+            r"\u{1b}]52;c;x\u{7}"
         );
     }
 
@@ -6230,6 +6657,21 @@ mod tests {
             Cli::try_parse_from(["hooklistener", "endpoint", "delete", "ep_123", "--yes"]).unwrap();
 
         assert!(cli.yes);
+    }
+
+    #[test]
+    fn listen_accepts_explicit_insecure_dev_server_opt_in_as_global_flag() {
+        let cli = Cli::try_parse_from([
+            "hooklistener",
+            "listen",
+            "example",
+            "--ws-url",
+            "ws://dev.example.com",
+            "--allow-insecure-dev-server",
+        ])
+        .unwrap();
+
+        assert!(cli.allow_insecure_dev_server);
     }
 
     #[test]
@@ -6848,7 +7290,7 @@ mod tests {
         let receipt = listen_started_receipt(
             "github-webhooks",
             "http://localhost:3000/webhooks",
-            Some("wss://api.example.dev/socket/websocket"),
+            "wss://api.example.dev/socket/websocket",
             Some(&endpoint),
         );
 

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -30,8 +30,9 @@ type WsStream =
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
 type WsWrite = futures_util::stream::SplitSink<WsStream, Message>;
 
-// A 256 MiB body expands to about 342 MiB as unpadded base64. The remaining
-// space covers the Phoenix envelope and the advertised response-header limit.
+// Protocol v2 historically permits an envelope large enough for a 256 MiB body
+// encoded as base64. Keep that wire-format ceiling for compatibility, while the
+// local admission and buffering limits below remain deliberately much smaller.
 const TUNNEL_MAX_WEBSOCKET_MESSAGE_BYTES: usize = 402_653_184;
 const TUNNEL_PROTOCOL_VERSION: u64 = 2;
 const TUNNEL_MAX_FRAME_BYTES: usize = 65_536;
@@ -42,27 +43,32 @@ const LEGACY_MAX_RESPONSE_HEADER_BYTES: usize = 1_048_576;
 const MAX_RAW_BODY_BYTES: usize = 1_048_576;
 const UI_BODY_PREVIEW_BYTES: usize = 65_536;
 const REDACTED_SECRET: &str = "[REDACTED]";
+const LOCAL_MAX_TUNNEL_BODY_BYTES: usize = 16 * 1024 * 1024;
+const LOCAL_MAX_RESPONSE_HEADER_BYTES: usize = 1024 * 1024;
 const LOCAL_WORK_MAX_COUNT: usize = 8;
-const LOCAL_WORK_MAX_BYTES: usize = 256 * 1024 * 1024;
+const LOCAL_WORK_MAX_BYTES: usize = LOCAL_MAX_TUNNEL_BODY_BYTES;
 const INBOUND_STREAM_MAX_COUNT: usize = 16;
-const INBOUND_STREAM_MAX_BYTES: usize = TUNNEL_MAX_WEBSOCKET_MESSAGE_BYTES;
-const RESPONSE_BUFFER_MAX_BYTES: usize = 256 * 1024 * 1024;
+const INBOUND_STREAM_MAX_BYTES: usize = 32 * 1024 * 1024;
+const RESPONSE_BUFFER_MAX_BYTES: usize = LOCAL_MAX_TUNNEL_BODY_BYTES;
+const _: () = assert!(INBOUND_STREAM_MAX_BYTES < TUNNEL_MAX_WEBSOCKET_MESSAGE_BYTES);
 const OUTBOUND_CONTROL_MAX_COUNT: usize = 256;
 const OUTBOUND_RESPONSE_MAX_COUNT: usize = 256;
 const OUTBOUND_MAX_BYTES: usize = 4 * 1024 * 1024;
+const LOG_TEXT_MAX_BYTES: usize = 4 * 1024;
 pub const PRESENTATION_QUEUE_CAPACITY: usize = 100;
 const PRESENTATION_MAX_EVENT_BYTES: usize = 256 * 1024;
 
 fn bounded_budget_permits(bytes: usize, capacity: usize) -> Option<u32> {
-    bytes.max(1).min(capacity).try_into().ok()
+    if bytes > capacity {
+        return None;
+    }
+
+    bytes.max(1).try_into().ok()
 }
 
 fn inbound_stream_fits_budget(reserved_bytes: usize, stream_bytes: usize) -> bool {
-    if stream_bytes > INBOUND_STREAM_MAX_BYTES {
-        reserved_bytes == 0
-    } else {
-        reserved_bytes.saturating_add(stream_bytes) <= INBOUND_STREAM_MAX_BYTES
-    }
+    stream_bytes <= INBOUND_STREAM_MAX_BYTES
+        && reserved_bytes.saturating_add(stream_bytes) <= INBOUND_STREAM_MAX_BYTES
 }
 
 const DELIVERY_QUEUED: u8 = 0;
@@ -182,7 +188,6 @@ struct ResponseBufferReservation {
     budget: ResponseBufferBudget,
     permits: Vec<OwnedSemaphorePermit>,
     reserved_bytes: usize,
-    exclusive: bool,
 }
 
 impl ResponseBufferBudget {
@@ -197,7 +202,6 @@ impl ResponseBufferBudget {
             budget: self.clone(),
             permits: Vec::new(),
             reserved_bytes: 0,
-            exclusive: false,
         };
 
         reservation
@@ -218,13 +222,14 @@ impl ResponseBufferBudget {
 
 impl ResponseBufferReservation {
     fn try_grow_to(&mut self, total_bytes: usize) -> bool {
-        if self.exclusive || total_bytes <= self.reserved_bytes {
+        if total_bytes > RESPONSE_BUFFER_MAX_BYTES {
+            return false;
+        }
+        if total_bytes <= self.reserved_bytes {
             return true;
         }
 
-        let previous_permits = self.reserved_bytes.min(RESPONSE_BUFFER_MAX_BYTES);
-        let target_permits = total_bytes.min(RESPONSE_BUFFER_MAX_BYTES);
-        let additional_permits = target_permits.saturating_sub(previous_permits);
+        let additional_permits = total_bytes.saturating_sub(self.reserved_bytes);
 
         if additional_permits > 0 {
             let Some(permit) = self.budget.try_acquire(additional_permits) else {
@@ -234,7 +239,6 @@ impl ResponseBufferReservation {
         }
 
         self.reserved_bytes = total_bytes;
-        self.exclusive = total_bytes > RESPONSE_BUFFER_MAX_BYTES;
         true
     }
 }
@@ -405,13 +409,18 @@ impl TunnelLimits {
     fn from_join_response(response: &serde_json::Value) -> Self {
         let limits = response.get("limits");
         let advertised_body_limit = json_limit(limits, "max_body_bytes");
+        let body_limit = advertised_body_limit
+            .unwrap_or(LEGACY_MAX_REQUEST_BODY_BYTES)
+            .min(LOCAL_MAX_TUNNEL_BODY_BYTES);
 
         Self {
-            max_request_body_bytes: advertised_body_limit.unwrap_or(LEGACY_MAX_REQUEST_BODY_BYTES),
+            max_request_body_bytes: body_limit,
             max_response_body_bytes: advertised_body_limit
-                .unwrap_or(LEGACY_MAX_RESPONSE_BODY_BYTES),
+                .unwrap_or(LEGACY_MAX_RESPONSE_BODY_BYTES)
+                .min(LOCAL_MAX_TUNNEL_BODY_BYTES),
             max_response_header_bytes: json_limit(limits, "max_response_header_bytes")
-                .unwrap_or(LEGACY_MAX_RESPONSE_HEADER_BYTES),
+                .unwrap_or(LEGACY_MAX_RESPONSE_HEADER_BYTES)
+                .min(LOCAL_MAX_RESPONSE_HEADER_BYTES),
             ordered_response_headers: limits
                 .and_then(|limits| limits.get("response_headers_format"))
                 .and_then(|format| format.as_str())
@@ -437,6 +446,47 @@ fn json_value_to_string(v: &serde_json::Value) -> String {
         serde_json::Value::String(s) => s.clone(),
         _ => v.to_string(),
     }
+}
+
+fn decode_request_body_limited(
+    body_encoding: &str,
+    raw_body: &str,
+    max_bytes: usize,
+) -> Result<Vec<u8>> {
+    let body = match body_encoding {
+        "raw" => {
+            if raw_body.len() > max_bytes {
+                return Err(anyhow!(
+                    "Tunnel request body exceeds advertised limit ({} > {} bytes)",
+                    raw_body.len(),
+                    max_bytes
+                ));
+            }
+            raw_body.as_bytes().to_vec()
+        }
+        "base64" => {
+            let max_encoded_bytes = base64::encoded_len(max_bytes, false).unwrap_or(usize::MAX);
+            if raw_body.len() > max_encoded_bytes {
+                return Err(anyhow!(
+                    "Tunnel request body exceeds advertised limit (encoded body is too large)"
+                ));
+            }
+            URL_SAFE_NO_PAD
+                .decode(raw_body)
+                .context("Tunnel request contains invalid base64url body data")?
+        }
+        encoding => return Err(anyhow!("Unsupported tunnel body encoding: {encoding}")),
+    };
+
+    if body.len() > max_bytes {
+        return Err(anyhow!(
+            "Tunnel request body exceeds advertised limit ({} > {} bytes)",
+            body.len(),
+            max_bytes
+        ));
+    }
+
+    Ok(body)
 }
 
 fn should_forward_request_header(key: &str) -> bool {
@@ -507,6 +557,39 @@ fn response_header_bytes(headers: &reqwest::header::HeaderMap) -> usize {
     headers.iter().fold(0usize, |total, (name, value)| {
         total.saturating_add(name.as_str().len() + value.as_bytes().len() + 4)
     })
+}
+
+async fn read_response_body_limited(
+    response: &mut reqwest::Response,
+    max_bytes: usize,
+) -> Result<Vec<u8>> {
+    let content_length = response.content_length();
+    if content_length.is_some_and(|length| length > max_bytes as u64) {
+        return Err(anyhow!(
+            "Local response body exceeds tunnel limit (max {max_bytes} bytes)"
+        ));
+    }
+
+    let initial_capacity = content_length
+        .and_then(|length| usize::try_from(length).ok())
+        .unwrap_or(0)
+        .min(TUNNEL_MAX_FRAME_BYTES);
+    let mut bytes = Vec::with_capacity(initial_capacity);
+
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|error| anyhow!("Failed to read local response: {}", error.without_url()))?
+    {
+        if bytes.len().saturating_add(chunk.len()) > max_bytes {
+            return Err(anyhow!(
+                "Local response body exceeds tunnel limit (max {max_bytes} bytes)"
+            ));
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+
+    Ok(bytes)
 }
 
 #[cfg(test)]
@@ -793,6 +876,31 @@ fn bounded_presentation_text(value: &str) -> String {
     }
     format!("{}… [truncated]", &value[..end])
 }
+
+fn bounded_control_neutral_log_text(value: &str) -> String {
+    let mut output = String::with_capacity(value.len().min(LOG_TEXT_MAX_BYTES));
+    let mut truncated = false;
+
+    for character in value.chars() {
+        let rendered = if character.is_control() {
+            character.escape_default().collect::<String>()
+        } else {
+            character.to_string()
+        };
+
+        if output.len().saturating_add(rendered.len()) > LOG_TEXT_MAX_BYTES - 3 {
+            truncated = true;
+            break;
+        }
+        output.push_str(&rendered);
+    }
+
+    if truncated {
+        output.push_str("...");
+    }
+    output
+}
+
 fn with_forward_id(mut payload: serde_json::Value, forward_id: Option<&str>) -> serde_json::Value {
     if let Some(forward_id) = forward_id {
         payload["forward_id"] = serde_json::Value::String(forward_id.to_string());
@@ -922,10 +1030,11 @@ impl TunnelStreamAssembler {
                 return Err(anyhow!("Tunnel stream ended before all bytes arrived"));
             }
 
-            return Ok(Some(
-                serde_json::from_slice(&self.data)
-                    .context("Tunnel stream contains invalid JSON")?,
-            ));
+            let serialized_payload = std::mem::take(&mut self.data);
+            let payload = serde_json::from_slice(&serialized_payload)
+                .context("Tunnel stream contains invalid JSON")?;
+            drop(serialized_payload);
+            return Ok(Some(payload));
         }
 
         if self.data.len() == self.total_bytes {
@@ -1133,9 +1242,12 @@ fn tunnel_join_payload(
 fn validate_join_mode(response: &serde_json::Value, expected: &str) -> Result<()> {
     match response.get("mode").and_then(|mode| mode.as_str()) {
         Some(mode) if mode == expected => Ok(()),
-        Some(mode) => Err(anyhow!(
-            "Channel join failed: Server activated incompatible mode '{mode}' (expected '{expected}'); no requests were forwarded"
-        )),
+        Some(mode) => {
+            let mode = bounded_control_neutral_log_text(mode);
+            Err(anyhow!(
+                "Channel join failed: Server activated incompatible mode '{mode}' (expected '{expected}'); no requests were forwarded"
+            ))
+        }
         None => Err(anyhow!(
             "Channel join failed: Server did not confirm activation mode '{expected}'; upgrade the Hooklistener service before retrying"
         )),
@@ -1374,6 +1486,7 @@ impl TunnelClient {
 
     /// Connect to WebSocket and start listening for webhook events
     pub async fn connect_and_listen(&self) -> Result<()> {
+        api::validate_websocket_base_url(&self.base_url)?;
         info!(
             endpoint = %self.endpoint_slug,
             target = %self.target.display_url(),
@@ -1518,9 +1631,10 @@ impl TunnelClient {
                                     .and_then(|r| r.get("reason"))
                                     .and_then(|r| r.as_str())
                                     .unwrap_or("Unknown error");
+                                let reason = bounded_control_neutral_log_text(reason);
                                 let _ = self
                                     .event_tx
-                                    .send(TunnelEvent::ConnectionError(reason.to_string()))
+                                    .send(TunnelEvent::ConnectionError(reason.clone()))
                                     .await;
                                 return Err(anyhow!("Channel join failed: {}", reason));
                             }
@@ -1530,7 +1644,8 @@ impl TunnelClient {
                         write.send(Message::Pong(data)).await?;
                     }
                     Ok(Message::Close(frame)) => {
-                        return Err(anyhow!("WebSocket closed during join: {:?}", frame));
+                        let frame = bounded_control_neutral_log_text(&format!("{frame:?}"));
+                        return Err(anyhow!("WebSocket closed during join: {frame}"));
                     }
                     Err(e) => return Err(anyhow!("WebSocket error during join: {}", e)),
                     _ => {}
@@ -1571,11 +1686,13 @@ impl TunnelClient {
                 Ok(Some(msg)) => match msg {
                     Ok(Message::Text(text)) => {
                         if let Err(e) = self.handle_message(&text, &mut write).await {
-                            error!("Error handling message: {}", e);
+                            let error = bounded_control_neutral_log_text(&e.to_string());
+                            error!(error = %error, "Error handling message");
                         }
                     }
                     Ok(Message::Close(frame)) => {
-                        info!("WebSocket closed: {:?}", frame);
+                        let frame = bounded_control_neutral_log_text(&format!("{frame:?}"));
+                        info!(frame = %frame, "WebSocket closed");
                         let _ = self
                             .event_tx
                             .send(TunnelEvent::ConnectionError(
@@ -1628,10 +1745,12 @@ impl TunnelClient {
 
     async fn handle_message(&self, text: &str, write: &mut WsWrite) -> Result<()> {
         let msg: ChannelMessage = serde_json::from_str(text)?;
+        let log_topic = bounded_control_neutral_log_text(&msg.topic);
+        let log_event = bounded_control_neutral_log_text(&msg.event);
 
         debug!(
-            topic = %msg.topic,
-            event = %msg.event,
+            topic = %log_topic,
+            event = %log_event,
             "Received message"
         );
 
@@ -1681,8 +1800,7 @@ impl TunnelClient {
                             self.forward_webhook(request, write).await?;
                         }
                         Err(e) => {
-                            let err_msg =
-                                format!("Invalid webhook payload: {}. Data: {}", e, request_data);
+                            let err_msg = format!("Invalid webhook payload: {e}");
                             error!("{}", err_msg);
                             let _ = self
                                 .event_tx
@@ -1694,7 +1812,7 @@ impl TunnelClient {
                 }
             }
             _ => {
-                debug!("Unhandled event: {}", msg.event);
+                debug!(event = %log_event, "Unhandled event");
             }
         }
 
@@ -1753,11 +1871,50 @@ impl TunnelClient {
         // Send request
         let start_time = std::time::Instant::now();
         match req_builder.send().await {
-            Ok(response) => {
+            Ok(mut response) => {
                 let status = response.status();
                 let status_code = status.as_u16();
                 let response_headers = response_headers_to_map(response.headers());
-                let response_bytes = response.bytes().await.unwrap_or_default();
+                let response_bytes =
+                    match read_response_body_limited(&mut response, LEGACY_MAX_RESPONSE_BODY_BYTES)
+                        .await
+                    {
+                        Ok(response_bytes) => response_bytes,
+                        Err(error) => {
+                            let duration_ms = start_time.elapsed().as_millis() as u64;
+                            let error_message = error.to_string();
+
+                            error!(
+                                request_id = %request.id,
+                                error = %error_message,
+                                "Failed to read local response"
+                            );
+
+                            let _ = self
+                                .event_tx
+                                .send(TunnelEvent::ForwardError {
+                                    request_id: request.id.clone(),
+                                    target_url: target_with_query.to_string(),
+                                    error: error_message.clone(),
+                                    duration_ms,
+                                })
+                                .await;
+
+                            let payload = with_forward_id(
+                                serde_json::json!({
+                                    "request_id": &request.id,
+                                    "status": "error",
+                                    "proxied_to": target_with_query.as_str(),
+                                    "error": error_message,
+                                    "duration_ms": duration_ms,
+                                }),
+                                request.forward_id.as_deref(),
+                            );
+
+                            self.send_request_ack(write, payload).await?;
+                            return Ok(());
+                        }
+                    };
                 let (response_body, response_body_encoding) = encode_response_body(&response_bytes);
                 let duration_ms = start_time.elapsed().as_millis() as u64;
 
@@ -1797,7 +1954,7 @@ impl TunnelClient {
             Err(e) => {
                 let duration_ms = start_time.elapsed().as_millis() as u64;
 
-                let error_message = e.to_string();
+                let error_message = e.without_url().to_string();
 
                 error!(
                     request_id = %request.id,
@@ -1868,7 +2025,8 @@ impl TunnelClient {
                 }
                 Err(ref e) => {
                     let err_msg = e.to_string();
-                    warn!(error = %err_msg, "Tunnel connection attempt failed");
+                    let log_error = bounded_control_neutral_log_text(&err_msg);
+                    warn!(error = %log_error, "Tunnel connection attempt failed");
                     if is_fatal_error(&err_msg) {
                         let _ = self
                             .event_tx
@@ -2033,6 +2191,7 @@ impl TunnelForwarder {
     }
 
     pub async fn connect_and_forward(&self) -> Result<()> {
+        api::validate_api_base_url(&self.base_url)?;
         info!(
             local_host = %self.local_host,
             local_port = %self.local_port,
@@ -2233,9 +2392,11 @@ impl TunnelForwarder {
                                     .unwrap_or(false);
 
                                 let tunnel_type = if is_static { "static" } else { "ephemeral" };
+                                let log_subdomain = bounded_control_neutral_log_text(&subdomain);
+                                let log_tunnel_id = bounded_control_neutral_log_text(&tunnel_id);
                                 info!(
-                                    subdomain = %subdomain,
-                                    tunnel_id = %tunnel_id,
+                                    subdomain = %log_subdomain,
+                                    tunnel_id = %log_tunnel_id,
                                     tunnel_type = %tunnel_type,
                                     max_request_body_bytes = tunnel_limits.max_request_body_bytes,
                                     max_response_body_bytes = tunnel_limits.max_response_body_bytes,
@@ -2261,9 +2422,10 @@ impl TunnelForwarder {
                                     .and_then(|r| r.get("reason"))
                                     .and_then(|r| r.as_str())
                                     .unwrap_or("Unknown error");
+                                let reason = bounded_control_neutral_log_text(reason);
                                 let _ = self
                                     .event_tx
-                                    .send(TunnelEvent::ConnectionError(reason.to_string()))
+                                    .send(TunnelEvent::ConnectionError(reason.clone()))
                                     .await;
                                 return Err(anyhow!("Tunnel join failed: {}", reason));
                             }
@@ -2273,7 +2435,8 @@ impl TunnelForwarder {
                         write.send(Message::Pong(data)).await?;
                     }
                     Ok(Message::Close(frame)) => {
-                        return Err(anyhow!("WebSocket closed during join: {:?}", frame));
+                        let frame = bounded_control_neutral_log_text(&format!("{frame:?}"));
+                        return Err(anyhow!("WebSocket closed during join: {frame}"));
                     }
                     Err(e) => return Err(anyhow!("WebSocket error during join: {}", e)),
                     _ => {}
@@ -2323,11 +2486,13 @@ impl TunnelForwarder {
                             )
                             .await
                         {
-                            error!("Error handling tunnel message: {}", e);
+                            let error = bounded_control_neutral_log_text(&e.to_string());
+                            error!(error = %error, "Error handling tunnel message");
                         }
                     }
                     Ok(Message::Close(frame)) => {
-                        info!("Tunnel WebSocket closed: {:?}", frame);
+                        let frame = bounded_control_neutral_log_text(&format!("{frame:?}"));
+                        info!(frame = %frame, "Tunnel WebSocket closed");
                         self.emit_presentation(TunnelEvent::Disconnected);
                         break;
                     }
@@ -2390,10 +2555,12 @@ impl TunnelForwarder {
         runtime: &mut RelayRuntime,
     ) -> Result<()> {
         let msg: ChannelMessage = serde_json::from_str(text)?;
+        let log_topic = bounded_control_neutral_log_text(&msg.topic);
+        let log_event = bounded_control_neutral_log_text(&msg.event);
 
         debug!(
-            topic = %msg.topic,
-            event = %msg.event,
+            topic = %log_topic,
+            event = %log_event,
             "Received tunnel message"
         );
 
@@ -2458,7 +2625,9 @@ impl TunnelForwarder {
                                     "invalid_stream_frame",
                                 ))
                                 .await?;
-                            warn!(stream_id, error = %error, "Rejected invalid tunnel frame");
+                            let log_stream_id = bounded_control_neutral_log_text(&stream_id);
+                            let error = bounded_control_neutral_log_text(&error.to_string());
+                            warn!(stream_id = %log_stream_id, error = %error, "Rejected invalid tunnel frame");
                             return Ok(());
                         }
                     },
@@ -2494,10 +2663,12 @@ impl TunnelForwarder {
                     runtime.inbound_reserved_bytes = runtime
                         .inbound_reserved_bytes
                         .saturating_sub(assembler.total_bytes);
+                    let deadline_unix_ms = assembler.deadline_unix_ms;
+                    drop(assembler);
 
                     let delivery = match self.parse_local_delivery(
                         &payload,
-                        assembler.deadline_unix_ms,
+                        deadline_unix_ms,
                         tunnel_limits,
                     ) {
                         Ok(delivery) => delivery,
@@ -2505,19 +2676,26 @@ impl TunnelForwarder {
                             let request_id = payload
                                 .get("request_id")
                                 .and_then(serde_json::Value::as_str)
-                                .unwrap_or(&stream_id);
+                                .unwrap_or(&stream_id)
+                                .to_string();
+                            let error = error.to_string();
+                            drop(payload);
                             writer
                                 .control(delivery_error_message(
                                     tunnel_topic,
-                                    request_id,
+                                    &request_id,
                                     "invalid_relay_request",
                                     "known_not_executed",
-                                    &error.to_string(),
+                                    &error,
                                 ))
                                 .await?;
                             return Ok(());
                         }
                     };
+                    // Parsing clones the validated metadata and decodes the body into
+                    // LocalDelivery, so the larger serialized JSON representation is
+                    // no longer needed while the request waits for local capacity.
+                    drop(payload);
 
                     if runtime.active_deliveries.contains_key(&delivery.request_id) {
                         writer
@@ -2616,7 +2794,8 @@ impl TunnelForwarder {
                     .get("code")
                     .and_then(serde_json::Value::as_str)
                     .unwrap_or("stream_error");
-                warn!(code, "Tunnel stream failed");
+                let code = bounded_control_neutral_log_text(code);
+                warn!(code = %code, "Tunnel stream failed");
             }
             "buffered_summary" => {
                 let count = msg
@@ -2712,7 +2891,8 @@ impl TunnelForwarder {
                             .to_string();
 
                         if reason != "buffer_empty" {
-                            warn!(reason = %reason, "Buffered replay request rejected");
+                            let log_reason = bounded_control_neutral_log_text(&reason);
+                            warn!(reason = %log_reason, "Buffered replay request rejected");
                             let _ = self
                                 .event_tx
                                 .send(TunnelEvent::BufferedReplayFailed {
@@ -2732,7 +2912,7 @@ impl TunnelForwarder {
                 }
             }
             _ => {
-                debug!("Unhandled tunnel event: {}", msg.event);
+                debug!(event = %log_event, "Unhandled tunnel event");
             }
         }
 
@@ -2766,21 +2946,11 @@ impl TunnelForwarder {
             .get("body")
             .and_then(serde_json::Value::as_str)
             .unwrap_or("");
-        let body = match body_encoding {
-            "raw" => raw_body.as_bytes().to_vec(),
-            "base64" => URL_SAFE_NO_PAD
-                .decode(raw_body)
-                .context("Tunnel request contains invalid base64url body data")?,
-            encoding => return Err(anyhow!("Unsupported tunnel body encoding: {encoding}")),
-        };
-
-        if body.len() > tunnel_limits.max_request_body_bytes {
-            return Err(anyhow!(
-                "Tunnel request body exceeds advertised limit ({} > {} bytes)",
-                body.len(),
-                tunnel_limits.max_request_body_bytes
-            ));
-        }
+        let body = decode_request_body_limited(
+            body_encoding,
+            raw_body,
+            tunnel_limits.max_request_body_bytes,
+        )?;
 
         Ok(LocalDelivery {
             request_id,
@@ -2965,11 +3135,6 @@ impl TunnelForwarder {
                         .await;
                 }
 
-                let initial_capacity = response_content_length
-                    .unwrap_or(0)
-                    .min(tunnel_limits.max_response_body_bytes);
-                let mut response_bytes = Vec::with_capacity(initial_capacity);
-
                 let Some(mut response_reservation) =
                     response_budget.try_reserve(response_content_length)
                 else {
@@ -2986,6 +3151,11 @@ impl TunnelForwarder {
                         )
                         .await;
                 };
+
+                let initial_capacity = response_content_length
+                    .unwrap_or(0)
+                    .min(TUNNEL_MAX_FRAME_BYTES);
+                let mut response_bytes = Vec::with_capacity(initial_capacity);
 
                 loop {
                     match response.chunk().await {
@@ -3033,7 +3203,8 @@ impl TunnelForwarder {
                         }
                         Ok(None) => break,
                         Err(error) => {
-                            let error_msg = format!("Failed to read local response: {error}");
+                            let error_msg =
+                                format!("Failed to read local response: {}", error.without_url());
 
                             return self
                                 .report_tunnel_failure(
@@ -3048,8 +3219,13 @@ impl TunnelForwarder {
                     }
                 }
 
+                drop(response);
                 let response_body_preview = body_preview(&response_bytes, &response_headers);
+                drop(response_headers);
+                let presentation_response_headers =
+                    bounded_presentation_headers(response_header_pairs.iter().cloned());
                 let (response_body, body_encoding) = encode_response_body(&response_bytes);
+                drop(response_bytes);
                 let duration_ms = start_time.elapsed().as_millis() as u64;
 
                 info!(
@@ -3060,7 +3236,7 @@ impl TunnelForwarder {
                     "Request forwarded successfully"
                 );
 
-                if let Err(error) = self
+                let response_result = self
                     .send_framed_tunnel_response(
                         &writer,
                         &tunnel_topic,
@@ -3069,13 +3245,15 @@ impl TunnelForwarder {
                         serde_json::json!({
                             "request_id": request_id.clone(),
                             "status": status,
-                            "headers": response_header_pairs.clone(),
+                            "headers": response_header_pairs,
                             "body": response_body,
                             "body_encoding": body_encoding,
                         }),
                     )
-                    .await
-                {
+                    .await;
+                drop(response_reservation);
+
+                if let Err(error) = response_result {
                     return self
                         .report_tunnel_failure(
                             &request_id,
@@ -3092,13 +3270,13 @@ impl TunnelForwarder {
                     request_id,
                     status,
                     duration_ms,
-                    response_headers: bounded_presentation_headers(response_header_pairs),
+                    response_headers: presentation_response_headers,
                     response_body: response_body_preview,
                 });
             }
             Err(error) => {
                 let duration_ms = start_time.elapsed().as_millis() as u64;
-                let error_msg = format!("Failed to forward request: {error}");
+                let error_msg = format!("Failed to forward request: {}", error.without_url());
 
                 error!(
                     request_id = %request_id,
@@ -3132,6 +3310,7 @@ impl TunnelForwarder {
     ) -> Result<()> {
         let mut stream =
             OutboundTunnelStream::new(request_id, "response", deadline_unix_ms, &payload)?;
+        drop(payload);
 
         writer.response(stream.start_message(tunnel_topic)).await?;
 
@@ -3194,7 +3373,8 @@ impl TunnelForwarder {
                 }
                 Err(ref e) => {
                     let err_msg = e.to_string();
-                    warn!(error = %err_msg, "Tunnel connection attempt failed");
+                    let log_error = bounded_control_neutral_log_text(&err_msg);
+                    warn!(error = %log_error, "Tunnel connection attempt failed");
                     if is_fatal_error(&err_msg) {
                         let _ = self
                             .event_tx
@@ -3203,7 +3383,7 @@ impl TunnelForwarder {
                         return result;
                     }
 
-                    warn!(error = %err_msg, "Tunnel connection attempt failed; retrying");
+                    warn!(error = %log_error, "Tunnel connection attempt failed; retrying");
 
                     if start.elapsed() > Duration::from_secs(5) {
                         attempt = 0;
@@ -3415,6 +3595,50 @@ mod tests {
         assert_eq!(config.max_frame_size, Some(TUNNEL_MAX_FRAME_BYTES));
     }
 
+    #[tokio::test]
+    async fn test_read_response_body_limited_rejects_large_content_length() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/large")
+            .with_body("too large")
+            .create_async()
+            .await;
+        let mut response = reqwest::Client::new()
+            .get(format!("{}/large", server.url()))
+            .send()
+            .await
+            .unwrap();
+
+        let error = read_response_body_limited(&mut response, 4)
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("max 4 bytes"));
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_read_response_body_limited_rejects_large_chunked_body() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/chunked")
+            .with_chunked_body(|writer| writer.write_all(b"too large"))
+            .create_async()
+            .await;
+        let mut response = reqwest::Client::new()
+            .get(format!("{}/chunked", server.url()))
+            .send()
+            .await
+            .unwrap();
+
+        let error = read_response_body_limited(&mut response, 4)
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("max 4 bytes"));
+        mock.assert_async().await;
+    }
+
     #[test]
     fn test_framed_stream_round_trips_with_one_bounded_frame_in_flight() {
         let payload = serde_json::json!({
@@ -3439,6 +3663,7 @@ mod tests {
 
         assert_eq!(decoded.unwrap(), payload);
         assert_eq!(peak_in_flight, 1);
+        assert!(inbound.data.is_empty());
     }
 
     #[test]
@@ -3564,7 +3789,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tunnel_limits_use_join_response_contract() {
+    fn test_tunnel_limits_clamp_join_response_contract_to_local_maxima() {
         let response = serde_json::json!({
             "limits": {
                 "max_body_bytes": 268_435_456,
@@ -3575,16 +3800,52 @@ mod tests {
 
         let limits = TunnelLimits::from_join_response(&response);
 
-        assert_eq!(limits.max_request_body_bytes, 268_435_456);
-        assert_eq!(limits.max_response_body_bytes, 268_435_456);
-        assert_eq!(limits.max_response_header_bytes, 16_777_216);
+        assert_eq!(limits.max_request_body_bytes, LOCAL_MAX_TUNNEL_BODY_BYTES);
+        assert_eq!(limits.max_response_body_bytes, LOCAL_MAX_TUNNEL_BODY_BYTES);
+        assert_eq!(
+            limits.max_response_header_bytes,
+            LOCAL_MAX_RESPONSE_HEADER_BYTES
+        );
         assert!(limits.ordered_response_headers);
+    }
+
+    #[test]
+    fn test_tunnel_limits_clamp_untrusted_body_limit_to_local_maximum() {
+        let response = serde_json::json!({
+            "limits": {
+                "max_body_bytes": u64::MAX,
+                "max_response_header_bytes": u64::MAX
+            }
+        });
+
+        let limits = TunnelLimits::from_join_response(&response);
+
+        assert_eq!(
+            (
+                limits.max_request_body_bytes,
+                limits.max_response_body_bytes
+            ),
+            (LOCAL_MAX_TUNNEL_BODY_BYTES, LOCAL_MAX_TUNNEL_BODY_BYTES)
+        );
+        assert_eq!(
+            limits.max_response_header_bytes,
+            LOCAL_MAX_RESPONSE_HEADER_BYTES
+        );
     }
 
     #[test]
     fn test_tunnel_limits_keep_legacy_response_header_shape_by_default() {
         let limits = TunnelLimits::from_join_response(&serde_json::json!({}));
 
+        assert_eq!(limits.max_request_body_bytes, LEGACY_MAX_REQUEST_BODY_BYTES);
+        assert_eq!(
+            limits.max_response_body_bytes,
+            LEGACY_MAX_RESPONSE_BODY_BYTES
+        );
+        assert_eq!(
+            limits.max_response_header_bytes,
+            LEGACY_MAX_RESPONSE_HEADER_BYTES
+        );
         assert!(!limits.ordered_response_headers);
     }
 
@@ -3754,17 +4015,32 @@ mod tests {
     }
 
     #[test]
-    fn test_local_work_budget_bounds_concurrent_ten_megabyte_deliveries() {
+    fn test_log_text_is_control_neutral_and_bounded() {
+        let input = format!(
+            "relay\u{1b}]52;c;owned\u{7}\n{}",
+            "a".repeat(LOG_TEXT_MAX_BYTES)
+        );
+
+        let sanitized = bounded_control_neutral_log_text(&input);
+
+        assert!(sanitized.len() <= LOG_TEXT_MAX_BYTES);
+        assert!(!sanitized.chars().any(char::is_control));
+        assert!(sanitized.contains("\\u{1b}"));
+        assert!(sanitized.contains("\\n"));
+        assert!(sanitized.ends_with("..."));
+    }
+
+    #[test]
+    fn test_local_work_budget_prevents_concurrent_ten_megabyte_deliveries() {
         let budget = LocalWorkBudget::new();
         let ten_mib = 10 * 1024 * 1024;
-        let permits = (0..LOCAL_WORK_MAX_COUNT)
-            .map(|_| budget.try_acquire(ten_mib).unwrap())
-            .collect::<Vec<_>>();
+        let permit = budget.try_acquire(ten_mib).unwrap();
 
-        assert_eq!(budget.available_count(), 0);
+        assert_eq!(budget.available_count(), LOCAL_WORK_MAX_COUNT - 1);
+        assert_eq!(budget.available_bytes(), 6 * 1024 * 1024);
         assert!(budget.try_acquire(ten_mib).is_none());
 
-        drop(permits);
+        drop(permit);
         assert_eq!(budget.available_count(), LOCAL_WORK_MAX_COUNT);
         assert_eq!(budget.available_bytes(), LOCAL_WORK_MAX_BYTES);
     }
@@ -3812,31 +4088,24 @@ mod tests {
     }
 
     #[test]
-    fn test_local_work_budget_allows_one_oversized_delivery_exclusively() {
+    fn test_local_work_budget_rejects_oversized_delivery() {
         let budget = LocalWorkBudget::new();
-        let permit = budget.try_acquire(LOCAL_WORK_MAX_BYTES * 2).unwrap();
 
-        assert_eq!(budget.available_count(), LOCAL_WORK_MAX_COUNT - 1);
-        assert_eq!(budget.available_bytes(), 0);
-        assert!(budget.try_acquire(1).is_none());
-
-        drop(permit);
+        assert!(budget.try_acquire(LOCAL_WORK_MAX_BYTES + 1).is_none());
         assert_eq!(budget.available_count(), LOCAL_WORK_MAX_COUNT);
         assert_eq!(budget.available_bytes(), LOCAL_WORK_MAX_BYTES);
     }
 
     #[test]
-    fn test_response_buffer_budget_bounds_concurrent_ten_megabyte_responses() {
+    fn test_response_buffer_budget_prevents_concurrent_ten_megabyte_responses() {
         let budget = ResponseBufferBudget::new();
         let ten_mib = 10 * 1024 * 1024;
-        let permits = (0..25)
-            .map(|_| budget.try_reserve(Some(ten_mib)).unwrap())
-            .collect::<Vec<_>>();
+        let reservation = budget.try_reserve(Some(ten_mib)).unwrap();
 
         assert_eq!(budget.available_bytes(), 6 * 1024 * 1024);
         assert!(budget.try_reserve(Some(ten_mib)).is_none());
 
-        drop(permits);
+        drop(reservation);
         assert_eq!(budget.available_bytes(), RESPONSE_BUFFER_MAX_BYTES);
     }
 
@@ -3853,40 +4122,40 @@ mod tests {
     }
 
     #[test]
-    fn test_response_buffer_budget_allows_one_oversized_response_exclusively() {
+    fn test_response_buffer_budget_rejects_oversized_response() {
         let budget = ResponseBufferBudget::new();
-        let permit = budget
-            .try_reserve(Some(RESPONSE_BUFFER_MAX_BYTES * 2))
-            .unwrap();
 
-        assert_eq!(budget.available_bytes(), 0);
-        assert!(budget.try_reserve(Some(1)).is_none());
-
-        drop(permit);
+        assert!(
+            budget
+                .try_reserve(Some(RESPONSE_BUFFER_MAX_BYTES + 1))
+                .is_none()
+        );
         assert_eq!(budget.available_bytes(), RESPONSE_BUFFER_MAX_BYTES);
     }
 
     #[test]
-    fn test_unknown_response_length_can_upgrade_to_exclusive_reservation() {
+    fn test_unknown_response_length_cannot_grow_past_budget() {
         let budget = ResponseBufferBudget::new();
         let mut reservation = budget.try_reserve(None).unwrap();
 
         assert!(reservation.try_grow_to(RESPONSE_BUFFER_MAX_BYTES / 2));
-        assert!(reservation.try_grow_to(RESPONSE_BUFFER_MAX_BYTES * 2));
-        assert_eq!(budget.available_bytes(), 0);
-        assert!(budget.try_reserve(Some(1)).is_none());
+        assert!(!reservation.try_grow_to(RESPONSE_BUFFER_MAX_BYTES + 1));
+        assert_eq!(budget.available_bytes(), RESPONSE_BUFFER_MAX_BYTES / 2);
 
         drop(reservation);
         assert_eq!(budget.available_bytes(), RESPONSE_BUFFER_MAX_BYTES);
     }
 
     #[test]
-    fn test_inbound_stream_budget_allows_one_oversized_stream_exclusively() {
-        let oversized = INBOUND_STREAM_MAX_BYTES * 2;
+    fn test_inbound_stream_budget_rejects_oversized_stream() {
+        let oversized = INBOUND_STREAM_MAX_BYTES.saturating_add(1);
+        let encoded_body_bytes = base64::encoded_len(LOCAL_MAX_TUNNEL_BODY_BYTES, false).unwrap();
 
-        assert!(inbound_stream_fits_budget(0, oversized));
-        assert!(!inbound_stream_fits_budget(1, oversized));
-        assert!(!inbound_stream_fits_budget(oversized, 1));
+        assert_eq!(INBOUND_STREAM_MAX_BYTES, 32 * 1024 * 1024);
+        assert!(
+            encoded_body_bytes.saturating_add(TUNNEL_MAX_FRAME_BYTES) < INBOUND_STREAM_MAX_BYTES
+        );
+        assert!(!inbound_stream_fits_budget(0, oversized));
         assert!(inbound_stream_fits_budget(INBOUND_STREAM_MAX_BYTES - 1, 1));
     }
 
@@ -4700,5 +4969,21 @@ mod tests {
         let encoded = URL_SAFE_NO_PAD.encode(original);
         let decoded = URL_SAFE_NO_PAD.decode(&encoded).unwrap();
         assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn test_decode_request_body_limited_rejects_oversized_raw_body_before_copying() {
+        let error = decode_request_body_limited("raw", "12345", 4).unwrap_err();
+
+        assert!(error.to_string().contains("5 > 4 bytes"));
+    }
+
+    #[test]
+    fn test_decode_request_body_limited_rejects_oversized_base64_before_decoding() {
+        let encoded = URL_SAFE_NO_PAD.encode(b"12345");
+
+        let error = decode_request_body_limited("base64", &encoded, 4).unwrap_err();
+
+        assert!(error.to_string().contains("encoded body is too large"));
     }
 }

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -14,6 +14,8 @@ const GITHUB_REPO_OWNER: &str = "hooklistener";
 const GITHUB_REPO_NAME: &str = "hooklistener-cli";
 const CHECK_INTERVAL_HOURS: i64 = 24;
 const REQUEST_TIMEOUT_SECS: u64 = 5;
+const CHECKSUMS_ASSET_NAME: &str = "SHA256SUMS.txt";
+const MAX_CHECKSUM_MANIFEST_BYTES: usize = 64 * 1024;
 
 #[derive(Debug)]
 enum InstallMethod {
@@ -69,6 +71,21 @@ impl InstallMethod {
 #[derive(Debug, Deserialize)]
 struct GitHubRelease {
     tag_name: String,
+    #[serde(default)]
+    assets: Vec<GitHubAsset>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubAsset {
+    name: String,
+    browser_download_url: String,
+}
+
+#[derive(Debug)]
+struct PreparedBinaryUpdate {
+    release_tag: String,
+    archive_name: String,
+    checksum: String,
 }
 
 fn normalize_version(tag: &str) -> &str {
@@ -114,37 +131,9 @@ async fn check_latest_version() -> Result<Option<String>, UpdateError> {
 }
 
 async fn check_latest_version_from(base_url: &str) -> Result<Option<String>, UpdateError> {
-    let url = format!(
-        "{}/repos/{}/{}/releases/latest",
-        base_url.trim_end_matches('/'),
-        GITHUB_REPO_OWNER,
-        GITHUB_REPO_NAME
-    );
-
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
-        .user_agent(format!("hooklistener-cli/{}", CURRENT_VERSION))
-        .build()
-        .map_err(|e| UpdateError::CheckFailed(e.to_string()))?;
-
-    let response = client
-        .get(&url)
-        .send()
+    let release = fetch_latest_release_from(base_url)
         .await
-        .map_err(|e| UpdateError::CheckFailed(e.to_string()))?;
-
-    if !response.status().is_success() {
-        return Err(UpdateError::CheckFailed(format!(
-            "GitHub API returned {}",
-            response.status()
-        )));
-    }
-
-    let release: GitHubRelease = response
-        .json()
-        .await
-        .map_err(|e| UpdateError::CheckFailed(e.to_string()))?;
-
+        .map_err(UpdateError::CheckFailed)?;
     let remote_version = normalize_version(&release.tag_name).to_string();
 
     if is_newer(&remote_version, CURRENT_VERSION) {
@@ -152,6 +141,189 @@ async fn check_latest_version_from(base_url: &str) -> Result<Option<String>, Upd
     } else {
         Ok(None)
     }
+}
+
+fn github_client() -> Result<reqwest::Client, String> {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+        .user_agent(format!("hooklistener-cli/{CURRENT_VERSION}"))
+        .redirect(reqwest::redirect::Policy::custom(|attempt| {
+            if attempt.url().scheme() == "https" {
+                attempt.follow()
+            } else {
+                attempt.error("refusing a non-HTTPS release redirect")
+            }
+        }))
+        .build()
+        .map_err(|error| error.to_string())
+}
+
+async fn fetch_latest_release_from(base_url: &str) -> Result<GitHubRelease, String> {
+    let url = format!(
+        "{}/repos/{}/{}/releases/latest",
+        base_url.trim_end_matches('/'),
+        GITHUB_REPO_OWNER,
+        GITHUB_REPO_NAME
+    );
+
+    let client = github_client()?;
+
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|error| error.to_string())?;
+
+    if !response.status().is_success() {
+        return Err(format!("GitHub API returned {}", response.status()));
+    }
+
+    response.json().await.map_err(|error| error.to_string())
+}
+
+fn current_archive_name() -> String {
+    let extension = if cfg!(windows) { "zip" } else { "tar.gz" };
+    format!(
+        "hooklistener{}-{}.{}",
+        std::env::consts::EXE_SUFFIX,
+        self_update::get_target(),
+        extension
+    )
+}
+
+fn find_unique_asset<'a>(
+    release: &'a GitHubRelease,
+    asset_name: &str,
+) -> Result<&'a GitHubAsset, String> {
+    let mut matching_assets = release
+        .assets
+        .iter()
+        .filter(|asset| asset.name == asset_name);
+    let asset = matching_assets
+        .next()
+        .ok_or_else(|| format!("release is missing required asset {asset_name}"))?;
+
+    if matching_assets.next().is_some() {
+        return Err(format!(
+            "release contains duplicate assets named {asset_name}"
+        ));
+    }
+
+    Ok(asset)
+}
+
+fn parse_checksum_manifest(manifest: &str, archive_name: &str) -> Result<String, String> {
+    let mut expected_checksum = None;
+
+    for line in manifest.lines() {
+        let mut fields = line.split_whitespace();
+        let Some(checksum) = fields.next() else {
+            continue;
+        };
+        let Some(listed_name) = fields.next() else {
+            continue;
+        };
+        let listed_name = listed_name.strip_prefix('*').unwrap_or(listed_name);
+
+        if listed_name != archive_name {
+            continue;
+        }
+
+        if fields.next().is_some()
+            || checksum.len() != 64
+            || !checksum.bytes().all(|byte| byte.is_ascii_hexdigit())
+        {
+            return Err(format!(
+                "checksum manifest has a malformed entry for {archive_name}"
+            ));
+        }
+
+        if expected_checksum.is_some() {
+            return Err(format!(
+                "checksum manifest has duplicate entries for {archive_name}"
+            ));
+        }
+
+        expected_checksum = Some(checksum.to_ascii_lowercase());
+    }
+
+    expected_checksum
+        .ok_or_else(|| format!("checksum manifest is missing an entry for {archive_name}"))
+}
+
+async fn download_checksum_manifest(url: &str) -> Result<String, String> {
+    let parsed_url =
+        reqwest::Url::parse(url).map_err(|error| format!("invalid checksum asset URL: {error}"))?;
+    if parsed_url.scheme() != "https" {
+        return Err("checksum asset URL must use HTTPS".to_string());
+    }
+
+    let client = github_client()?;
+    let mut response = client
+        .get(parsed_url)
+        .send()
+        .await
+        .map_err(|error| format!("failed to download checksum manifest: {error}"))?;
+
+    if !response.status().is_success() {
+        return Err(format!(
+            "checksum manifest download returned {}",
+            response.status()
+        ));
+    }
+
+    if response
+        .content_length()
+        .is_some_and(|length| length > MAX_CHECKSUM_MANIFEST_BYTES as u64)
+    {
+        return Err("checksum manifest exceeds the size limit".to_string());
+    }
+
+    let mut manifest_bytes = Vec::new();
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|error| format!("failed to read checksum manifest: {error}"))?
+    {
+        if manifest_bytes.len().saturating_add(chunk.len()) > MAX_CHECKSUM_MANIFEST_BYTES {
+            return Err("checksum manifest exceeds the size limit".to_string());
+        }
+        manifest_bytes.extend_from_slice(&chunk);
+    }
+
+    String::from_utf8(manifest_bytes)
+        .map_err(|_| "checksum manifest is not valid UTF-8".to_string())
+}
+
+async fn prepare_binary_update() -> Result<Option<PreparedBinaryUpdate>, UpdateError> {
+    let release = fetch_latest_release_from("https://api.github.com")
+        .await
+        .map_err(UpdateError::UpdateFailed)?;
+    let version = normalize_version(&release.tag_name).to_string();
+    let update_available = self_update::version::bump_is_greater(CURRENT_VERSION, &version)
+        .map_err(|error| {
+            UpdateError::UpdateFailed(format!("release has an invalid version: {error}"))
+        })?;
+
+    if !update_available {
+        return Ok(None);
+    }
+
+    let archive_name = current_archive_name();
+    find_unique_asset(&release, &archive_name).map_err(UpdateError::UpdateFailed)?;
+    let checksums_asset =
+        find_unique_asset(&release, CHECKSUMS_ASSET_NAME).map_err(UpdateError::UpdateFailed)?;
+    let manifest = download_checksum_manifest(&checksums_asset.browser_download_url)
+        .await
+        .map_err(UpdateError::UpdateFailed)?;
+    let checksum =
+        parse_checksum_manifest(&manifest, &archive_name).map_err(UpdateError::UpdateFailed)?;
+
+    Ok(Some(PreparedBinaryUpdate {
+        release_tag: release.tag_name,
+        archive_name,
+        checksum,
+    }))
 }
 
 /// Persist the version check result to config. Silently ignores save errors.
@@ -233,22 +405,42 @@ async fn run_binary_self_update(json: bool) -> Result<()> {
         );
     }
 
-    let status = tokio::task::spawn_blocking(move || {
-        self_update::backends::github::Update::configure()
-            .repo_owner(GITHUB_REPO_OWNER)
-            .repo_name(GITHUB_REPO_NAME)
-            .bin_name("hooklistener")
-            .show_download_progress(!json)
-            .show_output(!json)
-            .no_confirm(json)
-            .current_version(CURRENT_VERSION)
-            .build()
-            .map_err(|e| UpdateError::UpdateFailed(e.to_string()))?
-            .update()
-            .map_err(|e| UpdateError::UpdateFailed(e.to_string()))
-    })
-    .await
-    .map_err(|e| UpdateError::UpdateFailed(e.to_string()))??;
+    let status = match prepare_binary_update().await? {
+        None => self_update::VersionStatus::UpToDate(CURRENT_VERSION.to_string()),
+        Some(prepared) => {
+            let PreparedBinaryUpdate {
+                release_tag,
+                archive_name,
+                checksum,
+            } = prepared;
+            let archive_name_for_matcher = archive_name;
+
+            tokio::task::spawn_blocking(move || {
+                self_update::backends::github::Update::configure()
+                    .repo_owner(GITHUB_REPO_OWNER)
+                    .repo_name(GITHUB_REPO_NAME)
+                    .bin_name("hooklistener")
+                    .release_tag(release_tag)
+                    .asset_matcher(move |assets| {
+                        assets
+                            .iter()
+                            .find(|asset| asset.name() == archive_name_for_matcher)
+                            .cloned()
+                    })
+                    .verify_checksum(self_update::Checksum::Sha256(checksum))
+                    .show_download_progress(!json)
+                    .show_output(!json)
+                    .no_confirm(json)
+                    .current_version(CURRENT_VERSION)
+                    .build()
+                    .map_err(|error| UpdateError::UpdateFailed(error.to_string()))?
+                    .update()
+                    .map_err(|error| UpdateError::UpdateFailed(error.to_string()))
+            })
+            .await
+            .map_err(|error| UpdateError::UpdateFailed(error.to_string()))??
+        }
+    };
 
     let new_version = normalize_version(status.version());
 
@@ -357,6 +549,101 @@ mod tests {
 
         assert!(matches!(result, Err(UpdateError::CheckFailed(_))));
         mock.assert_async().await;
+    }
+
+    #[test]
+    fn parse_checksum_manifest_returns_exact_archive_entry() {
+        let archive_name = "hooklistener-x86_64-unknown-linux-gnu.tar.gz";
+        let expected = "a".repeat(64);
+        let manifest = format!(
+            "{}  {}.sig\n{}  {}\n",
+            "b".repeat(64),
+            archive_name,
+            expected.to_uppercase(),
+            archive_name
+        );
+
+        let checksum = parse_checksum_manifest(&manifest, archive_name).unwrap();
+
+        assert_eq!(checksum, expected);
+    }
+
+    #[test]
+    fn parse_checksum_manifest_rejects_missing_archive_entry() {
+        let manifest = format!("{}  another-archive.tar.gz\n", "a".repeat(64));
+
+        let error = parse_checksum_manifest(&manifest, "hooklistener.tar.gz").unwrap_err();
+
+        assert!(
+            error.contains("missing an entry"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn parse_checksum_manifest_rejects_malformed_digest() {
+        let archive_name = "hooklistener.tar.gz";
+        let manifest = format!("not-a-sha256  {archive_name}\n");
+
+        let error = parse_checksum_manifest(&manifest, archive_name).unwrap_err();
+
+        assert!(
+            error.contains("malformed entry"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn parse_checksum_manifest_rejects_duplicate_archive_entries() {
+        let archive_name = "hooklistener.tar.gz";
+        let manifest = format!(
+            "{}  {archive_name}\n{}  {archive_name}\n",
+            "a".repeat(64),
+            "b".repeat(64)
+        );
+
+        let error = parse_checksum_manifest(&manifest, archive_name).unwrap_err();
+
+        assert!(
+            error.contains("duplicate entries"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn find_unique_asset_rejects_duplicate_exact_names() {
+        let release = GitHubRelease {
+            tag_name: "v2.0.0".to_string(),
+            assets: vec![
+                GitHubAsset {
+                    name: CHECKSUMS_ASSET_NAME.to_string(),
+                    browser_download_url: "https://example.com/one".to_string(),
+                },
+                GitHubAsset {
+                    name: CHECKSUMS_ASSET_NAME.to_string(),
+                    browser_download_url: "https://example.com/two".to_string(),
+                },
+            ],
+        };
+
+        let error = find_unique_asset(&release, CHECKSUMS_ASSET_NAME).unwrap_err();
+
+        assert!(
+            error.contains("duplicate assets"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn download_checksum_manifest_rejects_plain_http() {
+        let error = download_checksum_manifest("http://example.com/SHA256SUMS.txt")
+            .await
+            .unwrap_err();
+
+        assert!(
+            error.contains("must use HTTPS"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- removes committed diagnostic artifacts and hardens diagnostic redaction, permissions, and symlink handling
- sanitizes remote-sourced terminal output and bounds webhook and relay memory use
- makes release checksum verification mandatory across self-update and every installer
- rejects remote cleartext service URLs unless explicitly enabled for isolated development
- hardens auth polling, replay forwarding, exports, config loading, and release packaging

## Validation

- cargo test --all-features --locked: 425 unit tests and 6 integration tests passed
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo fmt --all -- --check
- npm installer regression tests and Node syntax checks
- shell installer syntax check

## Required follow-up

- [x] Confirm server-side revocation of the historical credential from the deleted diagnostics
- [x] Decide whether to purge the diagnostic artifacts from Git history or formally accept the credential as permanently burned
- [ ] Add independently signed release manifests; mandatory same-origin SHA-256 verification is implemented here but does not protect against compromised release credentials

## Local tooling gaps

cargo-audit, PowerShell, and ShellCheck were unavailable locally. CI continues to run cargo audit.