### PR TITLE
chore(release): Prepare v1.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hooklistener-cli"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hooklistener-cli"
-version = "1.8.0"
+version = "1.8.1"
 edition = "2024"
 autobins = false
 description = "A fast, terminal-based CLI for browsing webhooks, forwarding events, and exposing local servers"

--- a/npm/packages/hooklistener/package.json
+++ b/npm/packages/hooklistener/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hooklistener",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "A fast, terminal-based CLI for browsing webhooks, forwarding events, and exposing local servers",
   "license": "MIT",
   "repository": {

--- a/src/snapshots/hooklistener__ui__tests__listening_update_warning_80x24_snapshot.snap
+++ b/src/snapshots/hooklistener__ui__tests__listening_update_warning_80x24_snapshot.snap
@@ -23,5 +23,5 @@ expression: snapshot
  │                                                                            │
  │                                                                            │
  └────────────────────────────────────────────────────────────────────────────┘
- [WARN] UPDATE AVAILABLE   1.8.0 → 1.9.0   Run `hooklistener update`
+ [WARN] UPDATE AVAILABLE   1.8.1 → 1.9.0   Run `hooklistener update`
  Listen (0)  ↑↓ Select | Enter Details | / Search | Q Quit       API connected

--- a/src/snapshots/hooklistener__ui__tests__tunneling_update_warning_80x24_snapshot.snap
+++ b/src/snapshots/hooklistener__ui__tests__tunneling_update_warning_80x24_snapshot.snap
@@ -23,5 +23,5 @@ expression: snapshot
 
 
 
- [WARN] UPDATE AVAILABLE   1.8.0 → 1.9.0   Run `hooklistener update`
+ [WARN] UPDATE AVAILABLE   1.8.1 → 1.9.0   Run `hooklistener update`
  Tunnel (5)  ↑↓ | Enter Expand | A Menu | / Filter | Q Quit      API connected


### PR DESCRIPTION
## Summary

Prepares the **v1.8.1** release.

The v1.8.0 release is unrecoverable: its tag was pushed as a *lightweight* tag, so the Release workflow's annotated-tag guard rejected it, and the "v*.*.* tag immutability" ruleset now blocks deleting or re-pushing that tag. Rather than fight the immutable tag, this ships the same code as v1.8.1 via a fresh, properly annotated tag.

Version bump only — no functional changes since v1.8.0 (commit 0ee131e):
- `Cargo.toml`, `Cargo.lock`, `npm/packages/hooklistener/package.json`: `1.8.0` → `1.8.1`
- Update-warning UI snapshots: `1.8.0 → 1.9.0` → `1.8.1 → 1.9.0`

## Verification
- `cargo build`, `cargo test` (468 tests), `cargo fmt --check`, `cargo clippy --all-targets` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)