### PR TITLE
chore(release): Prepare v1.8.2; relax two-person release governance

### DIFF
--- a/.github/scripts/verify-release-governance.sh
+++ b/.github/scripts/verify-release-governance.sh
@@ -57,7 +57,6 @@ if ! jq -e '
     and any(
       $rules[];
       .type == "pull_request"
-      and (.parameters.required_approving_review_count // 0) >= 1
     )
     and any(
       $rules[];
@@ -73,7 +72,7 @@ if ! jq -e '
         )
     )
 ' "${main_rules}" >/dev/null; then
-  echo "::error::Effective main rules do not enforce the complete release check and review policy."
+  echo "::error::Effective main rules do not enforce the complete release check policy."
   exit 1
 fi
 
@@ -158,17 +157,10 @@ fi
 
 if ! jq -e '
   .name == "release"
-  and .can_admins_bypass == false
-  and any(
-    .protection_rules[]?;
-    .type == "required_reviewers"
-    and .prevent_self_review == true
-    and ((.reviewers // []) | length) >= 1
-  )
   and .deployment_branch_policy.protected_branches == false
   and .deployment_branch_policy.custom_branch_policies == true
 ' "${release_environment}" >/dev/null; then
-  echo "::error::The release environment must disable admin bypass, require non-self review, and use a custom deployment policy."
+  echo "::error::The release environment must exist and use a custom deployment policy."
   exit 1
 fi
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hooklistener-cli"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hooklistener-cli"
-version = "1.8.1"
+version = "1.8.2"
 edition = "2024"
 autobins = false
 description = "A fast, terminal-based CLI for browsing webhooks, forwarding events, and exposing local servers"

--- a/npm/packages/hooklistener/package.json
+++ b/npm/packages/hooklistener/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hooklistener",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "A fast, terminal-based CLI for browsing webhooks, forwarding events, and exposing local servers",
   "license": "MIT",
   "repository": {

--- a/scripts/release_workflow_contract_test.py
+++ b/scripts/release_workflow_contract_test.py
@@ -321,20 +321,11 @@ class GovernancePolicyTest(unittest.TestCase):
         self.assert_policy_fails(fixture)
 
     def test_release_environment_policy_is_exact(self) -> None:
-        for mutation in ("admin-bypass", "self-review", "extra-pattern"):
-            fixture = policy_fixture()
-            if mutation == "admin-bypass":
-                fixture["environment"]["can_admins_bypass"] = True
-            elif mutation == "self-review":
-                fixture["environment"]["protection_rules"][0][
-                    "prevent_self_review"
-                ] = False
-            else:
-                fixture["environment_policies"][0]["branch_policies"].append(
-                    {"id": 2, "name": "main"}
-                )
-            with self.subTest(mutation=mutation):
-                self.assert_policy_fails(fixture)
+        fixture = policy_fixture()
+        fixture["environment_policies"][0]["branch_policies"].append(
+            {"id": 2, "name": "main"}
+        )
+        self.assert_policy_fails(fixture)
 
 
 class MonotonicReleaseOrderTest(unittest.TestCase):

--- a/src/snapshots/hooklistener__ui__tests__listening_update_warning_80x24_snapshot.snap
+++ b/src/snapshots/hooklistener__ui__tests__listening_update_warning_80x24_snapshot.snap
@@ -23,5 +23,5 @@ expression: snapshot
  │                                                                            │
  │                                                                            │
  └────────────────────────────────────────────────────────────────────────────┘
- [WARN] UPDATE AVAILABLE   1.8.1 → 1.9.0   Run `hooklistener update`
+ [WARN] UPDATE AVAILABLE   1.8.2 → 1.9.0   Run `hooklistener update`
  Listen (0)  ↑↓ Select | Enter Details | / Search | Q Quit       API connected

--- a/src/snapshots/hooklistener__ui__tests__tunneling_update_warning_80x24_snapshot.snap
+++ b/src/snapshots/hooklistener__ui__tests__tunneling_update_warning_80x24_snapshot.snap
@@ -23,5 +23,5 @@ expression: snapshot
 
 
 
- [WARN] UPDATE AVAILABLE   1.8.1 → 1.9.0   Run `hooklistener update`
+ [WARN] UPDATE AVAILABLE   1.8.2 → 1.9.0   Run `hooklistener update`
  Tunnel (5)  ↑↓ | Enter Expand | A Menu | / Filter | Q Quit      API connected


### PR DESCRIPTION
## Summary

Ships **v1.8.2** and relaxes the release governance so a **solo maintainer** can cut releases.

### Why
v1.8.0 and v1.8.1 could not complete. The `#38` audit hardened releases to require a second, **non-author** human at two gates:
1. `main` branch rule: `required_approving_review_count >= 1` (a solo maintainer cannot self-approve their own PR), and
2. the `release` environment: a required reviewer with self-review forbidden and admin-bypass disabled (the deploy waits for that reviewer).

With a single maintainer, neither gate can be satisfied, so releases deadlock.

### Change
Drop **only** the two-person requirements from `verify-release-governance.sh`:
- No longer require `>= 1` PR approval (the pull-request flow itself is still required).
- No longer require a non-self `release`-environment reviewer or `can_admins_bypass == false`.

The governance contract test is updated to match.

### Retained safeguards
- Pull-request flow on `main`
- Strict required CI status checks (all 12) with pinned app integration
- Immutable release tags (`update`/`deletion` restricted)
- Restricted `v*.*.*` tag creation

### Companion config changes (outside this PR)
- `main` ruleset: required approvals set to **0**.
- `release` environment: the required reviewer is being removed so the deploy no longer blocks.

## Verification
`cargo build`, `cargo test` (468), `cargo fmt --check`, `cargo clippy --all-targets`, and `release_workflow_contract_test.py` (27) all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)