### PR TITLE
chore(release): Prepare v1.8.3; fix broken annotated-tag verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,12 @@ jobs:
             exit 1
           fi
 
+          # actions/checkout fetches the trigger ref as "+<sha>:refs/tags/<tag>",
+          # which materialises a lightweight local tag pointing straight at the
+          # commit. Re-fetch the real tag ref so annotation can be inspected.
+          retry_read git fetch --no-tags --force origin \
+            "refs/tags/${TAG_NAME}:refs/tags/${TAG_NAME}"
+
           if [[ "$(git cat-file -t "refs/tags/${TAG_NAME}")" != "tag" ]]; then
             echo "::error::Stable releases require an annotated Git tag."
             exit 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hooklistener-cli"
-version = "1.8.2"
+version = "1.8.3"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hooklistener-cli"
-version = "1.8.2"
+version = "1.8.3"
 edition = "2024"
 autobins = false
 description = "A fast, terminal-based CLI for browsing webhooks, forwarding events, and exposing local servers"

--- a/npm/packages/hooklistener/package.json
+++ b/npm/packages/hooklistener/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hooklistener",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "A fast, terminal-based CLI for browsing webhooks, forwarding events, and exposing local servers",
   "license": "MIT",
   "repository": {

--- a/src/snapshots/hooklistener__ui__tests__listening_update_warning_80x24_snapshot.snap
+++ b/src/snapshots/hooklistener__ui__tests__listening_update_warning_80x24_snapshot.snap
@@ -23,5 +23,5 @@ expression: snapshot
  │                                                                            │
  │                                                                            │
  └────────────────────────────────────────────────────────────────────────────┘
- [WARN] UPDATE AVAILABLE   1.8.2 → 1.9.0   Run `hooklistener update`
+ [WARN] UPDATE AVAILABLE   1.8.3 → 1.9.0   Run `hooklistener update`
  Listen (0)  ↑↓ Select | Enter Details | / Search | Q Quit       API connected

--- a/src/snapshots/hooklistener__ui__tests__tunneling_update_warning_80x24_snapshot.snap
+++ b/src/snapshots/hooklistener__ui__tests__tunneling_update_warning_80x24_snapshot.snap
@@ -23,5 +23,5 @@ expression: snapshot
 
 
 
- [WARN] UPDATE AVAILABLE   1.8.2 → 1.9.0   Run `hooklistener update`
+ [WARN] UPDATE AVAILABLE   1.8.3 → 1.9.0   Run `hooklistener update`
  Tunnel (5)  ↑↓ | Enter Expand | A Menu | / Filter | Q Quit      API connected


### PR DESCRIPTION
## Summary

Ships **v1.8.3** and fixes the release-pipeline bug that has blocked every release since #39.

### Root cause
The `Verify immutable tag and package versions` step (introduced in #39) checks:
```
git cat-file -t "refs/tags/${TAG_NAME}"   # expects "tag" (annotated)
```
against the **local** checkout. But `actions/checkout` fetches the trigger ref as `+<sha>:refs/tags/<tag>`, which creates a **lightweight** local tag pointing straight at the commit. So the check always saw a non-annotated tag and failed — even though the pushed tag *is* annotated on the remote. This broke **v1.8.0, v1.8.1, and v1.8.2** at the same step.

### Fix
Re-fetch the real tag ref before the annotation check:
```
git fetch --no-tags --force origin "refs/tags/${TAG_NAME}:refs/tags/${TAG_NAME}"
```
This replaces the lightweight local tag with the actual annotated tag object. Verified locally: a lightweight tag becomes `tag` after the fetch and peels to the release commit. (The publisher jobs' `verify-remote-release-tag.sh` already checked the remote correctly.)

## Verification
`release_workflow_contract_test.py` (27), `cargo test` (468), `cargo fmt --check`, `cargo clippy --all-targets` all pass locally, plus a live check of the fetch mechanism against the remote tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)