### PR TITLE
chore(release): Prepare v1.8.4; audit the committed lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
-      checks: write
     steps:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -81,10 +79,14 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install cargo-audit 0.22.2
         run: cargo install cargo-audit --version 0.22.2 --locked
+      # rustsec/audit-check runs `cargo generate-lockfile` before auditing, which
+      # audits freshly resolved dependencies rather than the committed ones and
+      # dirties Cargo.lock. Audit the checked-in lockfile directly instead.
       - name: Run cargo audit
-        uses: rustsec/audit-check@e9159ac5f7d7d873ce074ca134da2f445c0a4a61 # v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        run: cargo audit --file Cargo.lock
+      - name: Verify Cargo.lock is unchanged
+        shell: bash
+        run: git diff --exit-code -- Cargo.lock
 
   build:
     name: Build (${{ matrix.target }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,6 @@ jobs:
     permissions:
       actions: read
       contents: read
-      checks: write
-      issues: write
     steps:
       - name: Checkout exact tag
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -166,10 +164,23 @@ jobs:
       - name: Install cargo-audit 0.22.2
         run: cargo install cargo-audit --version 0.22.2 --locked
 
+      # Audited with the pinned cargo-audit binary instead of rustsec/audit-check
+      # because that action runs `cargo generate-lockfile` first. Regenerating the
+      # lockfile both audits dependencies the tag never locked and leaves
+      # Cargo.lock dirty, which makes the later `cargo publish --dry-run` abort.
       - name: Audit locked Rust dependencies
-        uses: rustsec/audit-check@e9159ac5f7d7d873ce074ca134da2f445c0a4a61 # v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        run: cargo audit --file Cargo.lock
+
+      - name: Verify verification left the tagged tree pristine
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "::error::Release verification modified the checkout; cargo publish requires a clean tree that matches the tag."
+            git --no-pager status --porcelain
+            git --no-pager diff --stat
+            exit 1
+          fi
 
       - name: Test npm installer
         run: node --test npm/packages/hooklistener/scripts/install.test.js

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hooklistener-cli"
-version = "1.8.3"
+version = "1.8.4"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hooklistener-cli"
-version = "1.8.3"
+version = "1.8.4"
 edition = "2024"
 autobins = false
 description = "A fast, terminal-based CLI for browsing webhooks, forwarding events, and exposing local servers"

--- a/npm/packages/hooklistener/package.json
+++ b/npm/packages/hooklistener/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hooklistener",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "A fast, terminal-based CLI for browsing webhooks, forwarding events, and exposing local servers",
   "license": "MIT",
   "repository": {

--- a/scripts/release_workflow_contract_test.py
+++ b/scripts/release_workflow_contract_test.py
@@ -849,17 +849,37 @@ class ReleaseWorkflowTest(unittest.TestCase):
                 self.assertNotRegex(workflow, r"\$\{[^}]+,,\}")
                 self.assertIn("tr '[:upper:]' '[:lower:]'", workflow)
 
-    def test_cargo_audit_install_is_pinned_locked_and_precedes_action(self) -> None:
+    def test_cargo_audit_is_pinned_and_audits_the_committed_lockfile(self) -> None:
         install = "cargo install cargo-audit --version 0.22.2 --locked"
+        audit = "cargo audit --file Cargo.lock"
 
         for workflow, job_name in ((self.ci, "audit"), (self.release, "verify")):
             body = job_body(workflow, job_name)
             with self.subTest(job=job_name):
                 self.assertIn(install, body)
-                self.assertLess(
-                    body.find(install),
-                    body.find("rustsec/audit-check@"),
+                self.assertIn(audit, body)
+                self.assertLess(body.find(install), body.find(audit))
+                # rustsec/audit-check regenerates Cargo.lock before auditing, so
+                # it audits dependencies the commit never locked and leaves the
+                # working tree dirty for `cargo publish --dry-run --locked`.
+                executable = "\n".join(
+                    line
+                    for line in body.splitlines()
+                    if not line.lstrip().startswith("#")
                 )
+                self.assertNotIn("rustsec/audit-check@", executable)
+                self.assertNotIn("generate-lockfile", executable)
+
+    def test_release_verification_asserts_a_pristine_tree_before_publishing(
+        self,
+    ) -> None:
+        body = job_body(self.release, "verify")
+        cleanliness = body.find("git status --porcelain")
+        dry_run = body.find("cargo publish --dry-run --locked")
+
+        self.assertNotEqual(cleanliness, -1)
+        self.assertNotEqual(dry_run, -1)
+        self.assertLess(cleanliness, dry_run)
 
     def test_every_release_asset_policy_is_exact_and_unique(self) -> None:
         expected = {

--- a/src/snapshots/hooklistener__ui__tests__listening_update_warning_80x24_snapshot.snap
+++ b/src/snapshots/hooklistener__ui__tests__listening_update_warning_80x24_snapshot.snap
@@ -23,5 +23,5 @@ expression: snapshot
  │                                                                            │
  │                                                                            │
  └────────────────────────────────────────────────────────────────────────────┘
- [WARN] UPDATE AVAILABLE   1.8.3 → 1.9.0   Run `hooklistener update`
+ [WARN] UPDATE AVAILABLE   1.8.4 → 1.9.0   Run `hooklistener update`
  Listen (0)  ↑↓ Select | Enter Details | / Search | Q Quit       API connected

--- a/src/snapshots/hooklistener__ui__tests__tunneling_update_warning_80x24_snapshot.snap
+++ b/src/snapshots/hooklistener__ui__tests__tunneling_update_warning_80x24_snapshot.snap
@@ -23,5 +23,5 @@ expression: snapshot
 
 
 
- [WARN] UPDATE AVAILABLE   1.8.3 → 1.9.0   Run `hooklistener update`
+ [WARN] UPDATE AVAILABLE   1.8.4 → 1.9.0   Run `hooklistener update`
  Tunnel (5)  ↑↓ | Enter Expand | A Menu | / Filter | Q Quit      API connected


### PR DESCRIPTION
## Why v1.8.3 never shipped

The `Verify release candidate` job failed at `cargo publish --dry-run --locked`:

```
error: 1 files in the working directory contain changes that were not yet committed into git:
Cargo.lock
```

`rustsec/audit-check` runs `cargo generate-lockfile` before auditing ([run 30155146990](https://github.com/hooklistener/hooklistener-cli/actions/runs/30155146990)):

```
[command]/home/runner/.cargo/bin/cargo generate-lockfile
     Locking 473 packages to latest Rust 1.92.0 compatible versions
```

That rewrote `Cargo.lock` in the tagged checkout, so the next step found a dirty tree and aborted. Nothing was published — crates.io and npm are still on 1.7.3.

## Fix

- Audit with the already-pinned `cargo-audit 0.22.2` binary against the committed lockfile (`cargo audit --file Cargo.lock`) in both `ci.yml` and `release.yml`, instead of the action. This also closes a real gap: the regenerated lockfile audited dependency versions the tag never locked, so an advisory affecting a pinned version could be resolved away before scanning.
- Release verification asserts a pristine tree before packaging, so any future step that dirties the checkout fails with a clear message rather than at `cargo publish`.
- Drop `checks: write` / `issues: write` from both audit jobs — only the action's annotations needed them.
- Contract test updated to pin the new invariant (pinned install → `cargo audit --file Cargo.lock`, no `rustsec/audit-check`, no `generate-lockfile`, cleanliness check before the dry run).

## Version bump

1.8.3 → 1.8.4 in `Cargo.toml`, the `hooklistener-cli` `Cargo.lock` entry, `npm/packages/hooklistener/package.json`, and the two update-warning snapshots.

## Verified locally

`cargo fmt --check`, `cargo clippy --locked -D warnings`, `cargo test --locked` (461 + 6 conformance), `python3 scripts/release_workflow_contract_test.py` (28), `node --test npm/.../install.test.js` (9), `npm pack --dry-run` (`hooklistener 1.8.4`, expected 4 files). The failing sequence itself — `cargo audit --file Cargo.lock` → clean `git status --porcelain` → `cargo publish --dry-run --locked` — passes on this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)