### PR TITLE
fix(ci): Scope Rust build caches to the runner image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,8 +111,15 @@ jobs:
         uses: dtolnay/rust-toolchain@387aeee55b189f024a4f6d94890c5b18d73339cc # 1.92.0
         with:
           targets: ${{ matrix.target }}
+      # rust-cache keys on `runner.os`, which is "Linux" for both ubuntu-latest
+      # and the ubuntu-22.04 image the release build pins for its glibc floor.
+      # Without the image in the key, a job restores C dependencies (aws-lc-sys)
+      # compiled against a different glibc and the link fails on undefined
+      # __isoc23_* symbols.
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: ${{ matrix.os }}
       - name: Build release
         run: cargo build --release --target ${{ matrix.target }} --locked
       - name: Upload artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,8 +291,14 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      # Keyed on the runner image, not just `runner.os`. ubuntu-22.04 (pinned
+      # above for the glibc floor) and CI's ubuntu-latest both report "Linux",
+      # so a shared key let this job restore aws-lc-sys objects compiled against
+      # glibc 2.38+ and fail to link against 2.35 on undefined __isoc23_*.
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: ${{ matrix.os }}
 
       - name: Build (cargo)
         run: cargo build --release --target ${{ matrix.target }} --locked

--- a/scripts/release_workflow_contract_test.py
+++ b/scripts/release_workflow_contract_test.py
@@ -881,6 +881,21 @@ class ReleaseWorkflowTest(unittest.TestCase):
         self.assertNotEqual(dry_run, -1)
         self.assertLess(cleanliness, dry_run)
 
+    def test_build_caches_are_scoped_to_the_runner_image(self) -> None:
+        # CI builds Linux on ubuntu-latest while the release pins ubuntu-22.04
+        # for its glibc floor. rust-cache keys on `runner.os` ("Linux" for both)
+        # and the job id ("build" in both workflows), so without the image in the
+        # key one job restores C artifacts (aws-lc-sys) built against a different
+        # glibc and linking fails on undefined __isoc23_* symbols.
+        for workflow, label in ((self.ci, "ci"), (self.release, "release")):
+            body = job_body(workflow, "build")
+            with self.subTest(workflow=label):
+                cache = body.find("Swatinem/rust-cache@")
+                self.assertNotEqual(cache, -1)
+                self.assertIn("key: ${{ matrix.os }}", body[cache:])
+
+        self.assertIn("os: ubuntu-22.04", job_body(self.release, "build"))
+
     def test_every_release_asset_policy_is_exact_and_unique(self) -> None:
         expected = {
             "SHA256SUMS.txt",


### PR DESCRIPTION
## Symptom

The v1.8.4 release run failed in `Build (x86_64-unknown-linux-gnu)` ([run 30157628075](https://github.com/hooklistener/hooklistener-cli/actions/runs/30157628075)), after `verify` had passed:

```
rust-lld: error: undefined symbol: __isoc23_sscanf
>>> referenced by bcm.c
>>>   f8e4fd781484bd36-bcm.o in archive libaws_lc_sys-*.rlib
rust-lld: error: undefined symbol: __isoc23_strtol
```

The same target and commit built fine in CI minutes earlier.

## Cause

`rust-cache` keys on `runner.os` and the job id. Both build jobs are named `build` and both report `runner.os == Linux`, so they share the key `v0-rust-build-Linux-x64-9aee4d9d-e4b8d6a7` — but CI builds Linux on `ubuntu-latest` (glibc 2.39) while the release pins `ubuntu-22.04` (glibc 2.35) for the glibc compatibility floor.

The release job restored CI's cache `full match: true`, so `aws-lc-sys` was never recompiled — the build log shows only `Compiling hooklistener-cli`. Its objects were compiled against glibc 2.38+ headers, where `sscanf`/`strtol` map to `__isoc23_*`, and those symbols don't exist in glibc 2.35.

Only C dependencies are exposed to this, which is why it stayed latent: `aws-lc-sys` entered the tree in #39, and every release before that was pure Rust across the boundary.

## Fix

Add the runner image to the cache key (`key: ${{ matrix.os }}`) in both build jobs, so the two images never share artifacts. Guarded by a new contract test.

## Note on v1.8.4

The tag is immutable, so recovery used the path in CONTRIBUTING.md: I deleted the poisoned cache entry (`v0-rust-build-Linux-x64-9aee4d9d-e4b8d6a7`, `refs/heads/main`) and re-ran the failed job on the original run, which then builds `aws-lc-sys` from source on 22.04. This PR prevents recurrence; it is not needed for v1.8.4 to ship.

## Verified

`python3 scripts/release_workflow_contract_test.py` (29 tests). Both workflows parse with the intended `with.key`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)